### PR TITLE
appmgr: handle tor address version change

### DIFF
--- a/appmgr/Cargo.lock
+++ b/appmgr/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "lazy_static",
  "linear-map",
  "log",
+ "nix 0.19.1",
  "openssl",
  "pest",
  "pest_derive",
@@ -601,7 +602,7 @@ dependencies = [
  "gcc",
  "libc",
  "mktemp",
- "nix",
+ "nix 0.11.1",
 ]
 
 [[package]]
@@ -1308,6 +1309,18 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]

--- a/appmgr/Cargo.toml
+++ b/appmgr/Cargo.toml
@@ -32,6 +32,7 @@ itertools = "0.9.0"
 lazy_static = "1.4"
 linear-map = { version = "1.2", features = ["serde_impl"] }
 log = "0.4.11"
+nix = "0.19.1"
 openssl = "0.10.30"
 pest = "2.1"
 pest_derive = "2.1"

--- a/appmgr/src/tor.rs
+++ b/appmgr/src/tor.rs
@@ -277,6 +277,16 @@ pub async fn set_svc(
     let ip = hidden_services.add(name.to_owned(), service);
     log::info!("Adding Tor hidden service {} to {}.", name, ETC_TOR_RC);
     write_services(&hidden_services).await?;
+    let addr_path = Path::new(HIDDEN_SERVICE_DIR_ROOT)
+        .join(format!("app-{}", name))
+        .join("hostname");
+    tokio::fs::remove_file(addr_path).await.or_else(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            Ok(())
+        } else {
+            Err(e)
+        }
+    })?;
     hidden_services.commit().await?;
     log::info!("Reloading Tor.");
     let svc_exit = std::process::Command::new("service")

--- a/appmgr/src/tor.rs
+++ b/appmgr/src/tor.rs
@@ -217,7 +217,7 @@ pub async fn read_tor_key(
     version: HiddenServiceVersion,
     timeout: Option<Duration>,
 ) -> Result<String, Error> {
-    log::info!("Retrieving Tor hidden service address for {}.", name);
+    log::info!("Retrieving Tor hidden service key for {}.", name);
     let addr_path = Path::new(HIDDEN_SERVICE_DIR_ROOT)
         .join(format!("app-{}", name))
         .join(match version {
@@ -287,6 +287,7 @@ pub async fn set_svc(
             Err(e)
         }
     })?;
+    nix::unistd::sync();
     hidden_services.commit().await?;
     log::info!("Reloading Tor.");
     let svc_exit = std::process::Command::new("service")


### PR DESCRIPTION
this might break everything. It deletes the hostname (but not the key) on app install, before reloading tor.