### PR TITLE
remove X char from product_key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ buster.img:
 	mv 2020-08-20-raspios-buster-armhf-lite.img buster.img
 
 product_key:
-	echo "X\c" > product_key
-	cat /dev/random | base32 | head -c11 | tr '[:upper:]' '[:lower:]' >> product_key
+	cat /dev/random | base32 | head -c11 | tr '[:upper:]' '[:lower:]' > product_key
 
 appmgr/target/armv7-unknown-linux-gnueabihf/release/appmgr: $(APPMGR_SRC)
 	docker run --rm -it -v ~/.cargo/registry:/root/.cargo/registry -v "$(shell pwd)":/home/rust/src start9/rust-arm-cross:latest sh -c "(cd appmgr && cargo build --release --features=production)"


### PR DESCRIPTION
Greetings Start9Labs,

In my attempt to build and run embassy-os from source, I uncovered a bug in the Makefile rule for product_key. The initial like echoing "X" into the file introduces a character which does not fit the charset for a product key. I removed that line, and turned the following one-liner from an append ">>" to a redirect ">". This is my first PR with your org, so apologies if I've botched the formatting in some way.

Thanks,
Rob
