### PR TITLE
ui: copy button for tor address spec

### DIFF
--- a/ui/src/app/pages/server-routes/server-specs/server-specs.page.html
+++ b/ui/src/app/pages/server-routes/server-specs/server-specs.page.html
@@ -20,16 +20,14 @@
 
     <ion-item-group>
       <ion-item *ngFor="let spec of (server.specs | async) | keyvalue : asIsOrder" [class.break-all]="spec.key === 'Tor Address'">
-        <ion-label class="ion-text-wrap" style="display: flex; justify-content: space-between; align-items: center;">
-          <div>
-            <h2>{{ spec.key }}</h2>
-            <p *ngIf="spec.value | isValidEmver">{{ spec.value | displayEmver }}</p>
-            <p *ngIf="!(spec.value | isValidEmver)">{{ spec.value }}</p>
-          </div>
-          <ion-button *ngIf="spec.key === 'Tor Address'" fill="clear" (click)="copyTor()">
-            <ion-icon slot="icon-only" name="copy-outline" color="primary"></ion-icon>
-          </ion-button>
+        <ion-label class="ion-text-wrap">
+          <h2>{{ spec.key }}</h2>
+          <p *ngIf="spec.value | isValidEmver">{{ spec.value | displayEmver }}</p>
+          <p *ngIf="!(spec.value | isValidEmver)">{{ spec.value }}</p>
         </ion-label>
+        <ion-button slot="end" *ngIf="spec.key === 'Tor Address'" fill="clear" (click)="copyTor()">
+          <ion-icon slot="icon-only" name="copy-outline" color="primary"></ion-icon>
+        </ion-button>
       </ion-item>
     </ion-item-group>
   </ng-container>

--- a/ui/src/app/pages/server-routes/server-specs/server-specs.page.html
+++ b/ui/src/app/pages/server-routes/server-specs/server-specs.page.html
@@ -19,12 +19,16 @@
     </ion-item>
 
     <ion-item-group>
-      <!-- TODO: Tor address needs a copy button. -->
       <ion-item *ngFor="let spec of (server.specs | async) | keyvalue : asIsOrder" [class.break-all]="spec.key === 'Tor Address'">
-        <ion-label class="ion-text-wrap">
-          <h2>{{ spec.key }}</h2>
-          <p *ngIf="spec.value | isValidEmver">{{ spec.value | displayEmver }}</p>
-          <p *ngIf="!(spec.value | isValidEmver)">{{ spec.value }}</p>
+        <ion-label class="ion-text-wrap" style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2>{{ spec.key }}</h2>
+            <p *ngIf="spec.value | isValidEmver">{{ spec.value | displayEmver }}</p>
+            <p *ngIf="!(spec.value | isValidEmver)">{{ spec.value }}</p>
+          </div>
+          <ion-button *ngIf="spec.key === 'Tor Address'" fill="clear" (click)="copyTor()">
+            <ion-icon slot="icon-only" name="copy-outline" color="primary"></ion-icon>
+          </ion-button>
         </ion-label>
       </ion-item>
     </ion-item-group>


### PR DESCRIPTION
This PR adds a copy to clipboard button for the Embassy's `Tor Address` found under server specs.

I did not see an associated issue but there was a `TODO:` in the code.

Note: This is my first PR. I reviewed the contributing docs but apologies if I've missed anything.