### PR TITLE
ui: add go to service button on marketplace listing

### DIFF
--- a/ui/src/app/pages/apps-routes/app-available-show/app-available-show.page.html
+++ b/ui/src/app/pages/apps-routes/app-available-show/app-available-show.page.html
@@ -54,6 +54,9 @@
     </ion-button>
 
     <div *ngIf="vars.versionInstalled && vars.status !== 'INSTALLING' ">
+      <ion-button *ngIf="vars.versionInstalled" class="main-action-button" expand="block" fill="outline" [routerLink]="['/services', 'installed', vars.id]">
+        Go to Service
+      </ion-button>
       <ion-button *ngIf="installedStatus === 'installed-below'" class="main-action-button" expand="block" fill="outline" color="success" (click)="update('update')">
         Update to {{ vars.versionViewing | displayEmver }}
       </ion-button>

--- a/ui/src/app/pages/apps-routes/app-available-show/app-available-show.page.html
+++ b/ui/src/app/pages/apps-routes/app-available-show/app-available-show.page.html
@@ -54,7 +54,7 @@
     </ion-button>
 
     <div *ngIf="vars.versionInstalled && vars.status !== 'INSTALLING' ">
-      <ion-button *ngIf="vars.versionInstalled" class="main-action-button" expand="block" fill="outline" [routerLink]="['/services', 'installed', vars.id]">
+      <ion-button class="main-action-button" expand="block" fill="outline" [routerLink]="['/services', 'installed', vars.id]">
         Go to Service
       </ion-button>
       <ion-button *ngIf="installedStatus === 'installed-below'" class="main-action-button" expand="block" fill="outline" color="success" (click)="update('update')">


### PR DESCRIPTION
Adding a button for "Go to Service" from a marketplace listing.

Reference: #188 

Note: `[routerLink]` looked like the way routing over to the services page would be handled but if there's a more appropriate way, let me know.

