### PR TITLE
Agent/feature/actions fix

### DIFF
--- a/agent/src/Lib/External/AppManifest.hs
+++ b/agent/src/Lib/External/AppManifest.hs
@@ -110,7 +110,7 @@ instance FromJSON AppManifest where
         appManifestDependencies   <- o .:? "dependencies" .!= HM.empty >>= traverse parseDepInfo
         appManifestUninstallAlert <- o .:? "uninstall-alert"
         appManifestRestoreAlert   <- o .:? "restore-alert"
-        appManifestActions        <- o .: "actions"
+        appManifestActions        <- o .:? "actions"
         pure $ AppManifest { .. }
         where
             parsePortMapping = withObject "Port Mapping" $ \o -> liftA2 (,) (o .: "tor") (o .: "internal")

--- a/agent/src/Lib/External/AppManifest.hs
+++ b/agent/src/Lib/External/AppManifest.hs
@@ -88,7 +88,7 @@ data AppManifest where
                     , appManifestDependencies :: HM.HashMap AppId VersionRange
                     , appManifestUninstallAlert :: Maybe Text
                     , appManifestRestoreAlert   :: Maybe Text
-                    , appManifestActions :: [Action]
+                    , appManifestActions :: Maybe [Action]
                     } -> AppManifest
 
 uiAvailable :: AppManifest -> Bool


### PR DESCRIPTION
make actions optional in manifest for backwards compatibility, otherwise all other services will need to be re-released with this key added to the manifest 