### PR TITLE
Nginx: allow infinite body sizes

### DIFF
--- a/appmgr/src/nginx-standard.conf.template
+++ b/appmgr/src/nginx-standard.conf.template
@@ -9,6 +9,7 @@ server {{
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 0;
     }}
 }}
 server {{

--- a/appmgr/src/nginx.conf.template
+++ b/appmgr/src/nginx.conf.template
@@ -4,5 +4,6 @@ server {{
     location / {{
         proxy_pass http://{app_ip}:{internal_port}/;
         proxy_set_header Host $host;
+        client_max_body_size 0;
     }}
 }}


### PR DESCRIPTION
Update nginx templates with client_max_body_size 0;, to eliminate "file too large" errors while uploading to filebrowser.