### PR TITLE
disable buffering in nginx

### DIFF
--- a/appmgr/src/nginx-standard.conf.template
+++ b/appmgr/src/nginx-standard.conf.template
@@ -10,6 +10,8 @@ server {{
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 0;
+        proxy_request_buffering off;
+        proxy_buffering off;
     }}
 }}
 server {{

--- a/appmgr/src/nginx.conf.template
+++ b/appmgr/src/nginx.conf.template
@@ -5,5 +5,7 @@ server {{
         proxy_pass http://{app_ip}:{internal_port}/;
         proxy_set_header Host $host;
         client_max_body_size 0;
+        proxy_request_buffering off;
+        proxy_buffering off;
     }}
 }}

--- a/appmgr/src/version/v0_2_12.rs
+++ b/appmgr/src/version/v0_2_12.rs
@@ -1,0 +1,38 @@
+use super::*;
+use std::os::unix::process::ExitStatusExt;
+
+const V0_2_12: emver::Version = emver::Version::new(0, 2, 12, 0);
+
+pub struct Version;
+#[async_trait]
+impl VersionT for Version {
+    type Previous = v0_2_11::Version;
+    fn new() -> Self {
+        Version
+    }
+    fn semver(&self) -> &'static emver::Version {
+        &V0_2_12
+    }
+    async fn up(&self) -> Result<(), Error> {
+        crate::tor::write_lan_services(
+            &crate::tor::services_map(&PersistencePath::from_ref(crate::SERVICES_YAML)).await?,
+        )
+        .await?;
+        let svc_exit = std::process::Command::new("service")
+            .args(&["nginx", "reload"])
+            .status()?;
+        crate::ensure_code!(
+            svc_exit.success(),
+            crate::error::GENERAL_ERROR,
+            "Failed to Reload Nginx: {}",
+            svc_exit
+                .code()
+                .or_else(|| { svc_exit.signal().map(|a| 128 + a) })
+                .unwrap_or(0)
+        );
+        Ok(())
+    }
+    async fn down(&self) -> Result<(), Error> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Disables both request and response buffering in nginx, and creates a migration script for 0.2.11 -> 0.2.12.

Fixes https://github.com/Start9Labs/embassy-os/issues/271