### PR TITLE
fixes post process build failure step

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -322,6 +322,12 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         },
+        "typescript": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+          "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+          "dev": true
+        },
         "webpack-sources": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.0.1.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "@types/marked": "^1.1.0",
     "@types/node": "^14.11.10",
     "@types/uuid": "^8.0.0",
-    "node-html-parser": "^2.0.0",
+    "node-html-parser": "2.0.0",
     "ts-node": "^9.1.0",
     "tslint": "^6.1.0",
     "typescript": "4.0.5"


### PR DESCRIPTION
fixes #370 

Turns out there was a breaking change in that package that was not remedied until 4.x. However we can't upgrade to 4.1.2 because it requires typescript 4.1.5. We can't upgrade to typescript 4.1.5 because Angular requires it to be less than 4.1.0. This is remedied in the 0.3.0 branch where we've upgraded Angular to 11.x.

This is the source of all of the build from source errors. The reason none of us caught it is due to cached node_modules directories on each of our machines, which prevented our dev machines for upgrading the dependency. If you wish to verify this, dollars to donuts you will not be able to build the UI code if you blow up your node_modules directory and don't merge in this change.