### PR TITLE
Fix "n is undefined" config spec change bug

### DIFF
--- a/ui/src/app/app-config/config-cursor.ts
+++ b/ui/src/app/app-config/config-cursor.ts
@@ -298,6 +298,7 @@ export class ConfigCursor<T extends ValueType> {
     const mappedCfg = this.mappedConfig()
     if (cfg && mappedCfg && typeof cfg === 'object' && typeof mappedCfg === 'object') {
       const spec = this.spec()
+      if (spec === undefined) return true
       let allKeys: Set<string>
       if (spec.type === 'union') {
         let unionSpec = spec as  ValueSpecOf<'union'>


### PR DESCRIPTION
Fixes the issue where an old config with a new config spec sometimes renders the config inaccessible, with the error `n is undefined`