### PR TITLE
package logs rpc endpoint

### DIFF
--- a/appmgr/src/error.rs
+++ b/appmgr/src/error.rs
@@ -52,6 +52,7 @@ pub enum ErrorKind {
     ParseTimestamp = 44,
     ParseSysInfo = 45,
     WifiError = 46,
+    Journald = 47,
 }
 impl ErrorKind {
     pub fn as_str(&self) -> &'static str {
@@ -103,6 +104,7 @@ impl ErrorKind {
             ParseTimestamp => "Timestamp Parsing Error",
             ParseSysInfo => "System Info Parsing Error",
             WifiError => "Wifi Internal Error",
+            Journald => "Journald Error",
         }
     }
 }

--- a/appmgr/src/lib.rs
+++ b/appmgr/src/lib.rs
@@ -31,6 +31,7 @@ pub mod hostname;
 pub mod id;
 pub mod inspect;
 pub mod install;
+pub mod logs;
 pub mod manager;
 pub mod middleware;
 pub mod migration;
@@ -77,7 +78,8 @@ pub fn main_api() -> Result<(), RpcError> {
     install::uninstall,
     config::config,
     control::start,
-    control::stop
+    control::stop,
+    logs::logs,
 ))]
 pub fn package() -> Result<(), RpcError> {
     Ok(())

--- a/appmgr/src/logs.rs
+++ b/appmgr/src/logs.rs
@@ -1,0 +1,179 @@
+use std::time::{UNIX_EPOCH, Duration};
+
+use serde::{Deserialize, Serialize};
+
+use chrono::{DateTime, Utc, TimeZone};
+use clap::ArgMatches;
+use rpc_toolkit::command;
+use tokio::process::Command;
+
+use crate::context::{EitherContext, RpcContext};
+use crate::util::display_serializable;
+use crate::Error;
+use crate::error::ResultExt;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+
+pub struct LogResponse {
+    entries: Vec<LogEntry>,
+    start_cursor: String,
+    end_cursor: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct CursorLogEntry {
+    timestamp: String,
+    message: String,
+    cursor: String,
+}
+impl std::fmt::Display for CursorLogEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} {} {}", self.timestamp, self.message, self.cursor)
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct LogEntry {
+    timestamp: String,
+    message: String,
+}
+impl std::fmt::Display for LogEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} {}", self.timestamp, self.message)
+    }
+}
+
+// TODO
+fn display_logs(all: LogResponse, matches: &ArgMatches<'_>) {
+    use prettytable::*;
+
+    if matches.is_present("format") {
+        return display_serializable(all, matches);
+    }
+
+    let mut table = Table::new();
+    table.add_row(row![bc =>
+        "TIMESTAMP",
+        "MESSAGE",
+    ]);
+    for entry in all.entries {
+        let row = row![&format!("{}", entry.timestamp), &entry.message,];
+        table.add_row(row);
+    }
+    table.print_tty(false);
+}
+
+#[command(rpc_only)]
+pub async fn logs(
+    #[context] _: EitherContext,
+    #[arg] id: String,
+    #[arg] limit: Option<usize>,
+    #[arg] cursor: Option<String>,
+    #[arg] reverse: Option<bool>,
+) -> Result<LogResponse, Error> {
+    Ok(logs_inner(id, limit, cursor, reverse).await?)
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JournalctlEntry {
+    #[serde(rename="__REALTIME_TIMESTAMP")]
+    timestamp: String,
+    #[serde(rename="MESSAGE")]
+    message: String,
+    #[serde(rename="__CURSOR")]
+    cursor : String,
+    #[serde(skip, rename="__MONOTONIC_TIMESTAMP")]
+    monotonic_timestamp: String,
+    #[serde(skip, rename="_BOOT_ID")]
+    boot_id: String,
+}
+
+async fn logs_inner(
+    id: String,
+    limit: Option<usize>,
+    cursor: Option<String>,
+    reverse: Option<bool>,
+) -> Result<LogResponse, Error> {
+    println!("id = {:?}", id);
+
+    let limit = limit.unwrap_or(50);
+    let limit_formatted = format!("-n{}", limit);
+    println!("limit = {:?}", limit_formatted);
+
+    let mut args_out = vec![
+        "-u",
+        &id,
+        "--output=json",
+        "--output-fields=MESSAGE",
+        &limit_formatted,
+    ];
+
+    let cursor_formatted = format!("--after-cursor={}", cursor.clone().unwrap_or("".to_owned()));
+    if cursor.is_some() {
+        args_out.push(&cursor_formatted);
+        if reverse.is_some() {
+            args_out.push("--reverse");
+        }
+    }
+
+    println!("args_out = {:?}", args_out);
+
+    let out = Command::new("journalctl")
+        .args(args_out)
+        .output()
+        .await?
+        .stdout;
+    let out_string = String::from_utf8(out)?;
+    let journalctl_entries = out_string.lines();
+    println!("Found {} lines", journalctl_entries.clone().collect::<Vec<&str>>().len());
+    let mut cursor_log_entries = journalctl_entries
+        .map(|s| {
+            let journalctl_entry: JournalctlEntry = serde_json::from_str(s)
+                .with_kind(crate::ErrorKind::Unknown) // TODO find actual error
+                .unwrap();
+            CursorLogEntry { 
+                timestamp: DateTime::<Utc>::from(
+                    UNIX_EPOCH + Duration::from_micros(
+                        journalctl_entry.timestamp.parse::<u64>().unwrap()
+                    )
+                ).format("%Y-%m-%d %H:%M:%S.%f").to_string(),
+                message: journalctl_entry.message,
+                cursor: journalctl_entry.cursor,
+            }
+        })
+        .collect::<Vec<CursorLogEntry>>();
+    // reverse output again if we reversed it above
+    if cursor.is_some() && reverse.is_some() {
+        cursor_log_entries.reverse();
+    }
+    let mut log_entries:Vec<LogEntry> = Vec::new(); // TODO do this in a less horrible way
+    for cle in &cursor_log_entries {
+        log_entries.push(LogEntry{timestamp: cle.clone().timestamp, message: cle.clone().message});
+    }
+    Ok(
+        LogResponse {
+            entries: log_entries,
+            start_cursor: cursor_log_entries[0].clone().cursor,
+            end_cursor: cursor_log_entries[cursor_log_entries.len()-1].clone().cursor,
+        }
+    )
+}
+
+#[tokio::test]
+pub async fn test_logs() {
+    println!(
+        "{:#?}",
+        logs_inner(
+            // find a journalctl unit on your machine
+            "tor.service".to_owned(), 
+            Some(5), 
+            None,
+            // Some("s=1b8c418e28534400856c27b211dd94fd;i=e067d;b=97571c13a1284f87bc0639b5cff5acbe;m=3b6a68a823;t=5ca4e2be1576e;x=9a6f65a5917f8e9f".to_owned()), 
+            // Some(true), 
+            None,
+        )
+        .await
+        .unwrap()
+    )
+}

--- a/appmgr/src/logs.rs
+++ b/appmgr/src/logs.rs
@@ -12,9 +12,8 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio_stream::wrappers::LinesStream;
 
-use crate::context::{EitherContext};
+use crate::context::RpcContext;
 use crate::error::ResultExt;
-use crate::system::SYSTEMD_UNIT;
 use crate::util::Reversible;
 use crate::Error;
 
@@ -73,7 +72,7 @@ fn display_logs(all: LogResponse, _: &ArgMatches<'_>) {
 
 #[command(display(display_logs))]
 pub async fn logs(
-    #[context] _: EitherContext,
+    #[context] _: RpcContext,
     #[arg] id: String,
     #[arg] limit: Option<usize>,
     #[arg] cursor: Option<String>,

--- a/appmgr/src/logs.rs
+++ b/appmgr/src/logs.rs
@@ -1,41 +1,33 @@
-use std::time::{UNIX_EPOCH, Duration};
+use std::process::Stdio;
+use std::time::{Duration, UNIX_EPOCH};
 
-use serde::{Deserialize, Serialize};
-
-use chrono::{DateTime, Utc, TimeZone};
+use anyhow::anyhow;
+use chrono::{DateTime, TimeZone, Utc};
 use clap::ArgMatches;
+use futures::TryStreamExt;
 use rpc_toolkit::command;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
+use tokio_stream::wrappers::LinesStream;
 
 use crate::context::{EitherContext, RpcContext};
-use crate::util::display_serializable;
-use crate::Error;
 use crate::error::ResultExt;
+use crate::util::{display_serializable, Reversible};
+use crate::Error;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 
 pub struct LogResponse {
-    entries: Vec<LogEntry>,
-    start_cursor: String,
-    end_cursor: String,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-pub struct CursorLogEntry {
-    timestamp: String,
-    message: String,
-    cursor: String,
-}
-impl std::fmt::Display for CursorLogEntry {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{} {} {}", self.timestamp, self.message, self.cursor)
-    }
+    entries: Reversible<LogEntry>,
+    start_cursor: Option<String>,
+    end_cursor: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct LogEntry {
-    timestamp: String,
+    timestamp: DateTime<Utc>,
     message: String,
 }
 impl std::fmt::Display for LogEntry {
@@ -44,27 +36,13 @@ impl std::fmt::Display for LogEntry {
     }
 }
 
-// TODO
-fn display_logs(all: LogResponse, matches: &ArgMatches<'_>) {
-    use prettytable::*;
-
-    if matches.is_present("format") {
-        return display_serializable(all, matches);
+fn display_logs(all: LogResponse, _: &ArgMatches<'_>) {
+    for entry in all.entries.iter() {
+        println!("{}", entry);
     }
-
-    let mut table = Table::new();
-    table.add_row(row![bc =>
-        "TIMESTAMP",
-        "MESSAGE",
-    ]);
-    for entry in all.entries {
-        let row = row![&format!("{}", entry.timestamp), &entry.message,];
-        table.add_row(row);
-    }
-    table.print_tty(false);
 }
 
-#[command(rpc_only)]
+#[command(display(display_logs))]
 pub async fn logs(
     #[context] _: EitherContext,
     #[arg] id: String,
@@ -72,34 +50,40 @@ pub async fn logs(
     #[arg] cursor: Option<String>,
     #[arg] reverse: Option<bool>,
 ) -> Result<LogResponse, Error> {
-    Ok(logs_inner(id, limit, cursor, reverse).await?)
+    Ok(logs_inner(id, limit, cursor, reverse.unwrap_or(false)).await?)
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 struct JournalctlEntry {
-    #[serde(rename="__REALTIME_TIMESTAMP")]
+    #[serde(rename = "__REALTIME_TIMESTAMP")]
     timestamp: String,
-    #[serde(rename="MESSAGE")]
+    #[serde(rename = "MESSAGE")]
     message: String,
-    #[serde(rename="__CURSOR")]
-    cursor : String,
-    #[serde(skip, rename="__MONOTONIC_TIMESTAMP")]
-    monotonic_timestamp: String,
-    #[serde(skip, rename="_BOOT_ID")]
-    boot_id: String,
+    #[serde(rename = "__CURSOR")]
+    cursor: String,
+}
+impl JournalctlEntry {
+    fn log_entry(self) -> Result<(String, LogEntry), Error> {
+        Ok((
+            self.cursor,
+            LogEntry {
+                timestamp: DateTime::<Utc>::from(
+                    UNIX_EPOCH + Duration::from_micros(self.timestamp.parse::<u64>()?),
+                ),
+                message: self.message,
+            },
+        ))
+    }
 }
 
 async fn logs_inner(
     id: String,
     limit: Option<usize>,
     cursor: Option<String>,
-    reverse: Option<bool>,
+    reverse: bool,
 ) -> Result<LogResponse, Error> {
-    println!("id = {:?}", id);
-
     let limit = limit.unwrap_or(50);
     let limit_formatted = format!("-n{}", limit);
-    println!("limit = {:?}", limit_formatted);
 
     let mut args_out = vec![
         "-u",
@@ -112,52 +96,59 @@ async fn logs_inner(
     let cursor_formatted = format!("--after-cursor={}", cursor.clone().unwrap_or("".to_owned()));
     if cursor.is_some() {
         args_out.push(&cursor_formatted);
-        if reverse.is_some() {
+        if reverse {
             args_out.push("--reverse");
         }
     }
 
-    println!("args_out = {:?}", args_out);
-
-    let out = Command::new("journalctl")
+    let mut child = Command::new("journalctl")
         .args(args_out)
-        .output()
-        .await?
-        .stdout;
-    let out_string = String::from_utf8(out)?;
-    let journalctl_entries = out_string.lines();
-    println!("Found {} lines", journalctl_entries.clone().collect::<Vec<&str>>().len());
-    let mut cursor_log_entries = journalctl_entries
-        .map(|s| {
-            let journalctl_entry: JournalctlEntry = serde_json::from_str(s)
-                .with_kind(crate::ErrorKind::Unknown) // TODO find actual error
-                .unwrap();
-            CursorLogEntry { 
-                timestamp: DateTime::<Utc>::from(
-                    UNIX_EPOCH + Duration::from_micros(
-                        journalctl_entry.timestamp.parse::<u64>().unwrap()
-                    )
-                ).format("%Y-%m-%d %H:%M:%S.%f").to_string(),
-                message: journalctl_entry.message,
-                cursor: journalctl_entry.cursor,
-            }
-        })
-        .collect::<Vec<CursorLogEntry>>();
-    // reverse output again if we reversed it above
-    if cursor.is_some() && reverse.is_some() {
-        cursor_log_entries.reverse();
+        .stdout(Stdio::piped())
+        .spawn()?;
+    let out =
+        BufReader::new(child.stdout.take().ok_or_else(|| {
+            Error::new(anyhow!("No stdout available"), crate::ErrorKind::Journald)
+        })?);
+
+    let journalctl_entries = LinesStream::new(out.lines());
+
+    let mut deserialized_entries = journalctl_entries
+        .map_err(|e| Error::new(e, crate::ErrorKind::Journald))
+        .and_then(|s| {
+            futures::future::ready(
+                serde_json::from_str::<JournalctlEntry>(&s)
+                    .with_kind(crate::ErrorKind::Deserialization),
+            )
+        });
+
+    let mut entries = Vec::with_capacity(limit);
+    let mut start_cursor = None;
+
+    if let Some(first) = deserialized_entries.try_next().await? {
+        let (cursor, entry) = first.log_entry()?;
+        start_cursor = Some(cursor);
+        entries.push(entry);
     }
-    let mut log_entries:Vec<LogEntry> = Vec::new(); // TODO do this in a less horrible way
-    for cle in &cursor_log_entries {
-        log_entries.push(LogEntry{timestamp: cle.clone().timestamp, message: cle.clone().message});
+
+    let (end_cursor, entries) = deserialized_entries
+        .try_fold(
+            (start_cursor.clone(), entries),
+            |(_, mut acc), entry| async move {
+                let (cursor, entry) = entry.log_entry()?;
+                acc.push(entry);
+                Ok((Some(cursor), acc))
+            },
+        )
+        .await?;
+    let mut entries = Reversible::new(entries);
+    if reverse {
+        entries.reverse();
     }
-    Ok(
-        LogResponse {
-            entries: log_entries,
-            start_cursor: cursor_log_entries[0].clone().cursor,
-            end_cursor: cursor_log_entries[cursor_log_entries.len()-1].clone().cursor,
-        }
-    )
+    Ok(LogResponse {
+        entries,
+        start_cursor,
+        end_cursor,
+    })
 }
 
 #[tokio::test]
@@ -166,12 +157,12 @@ pub async fn test_logs() {
         "{:#?}",
         logs_inner(
             // find a journalctl unit on your machine
-            "tor.service".to_owned(), 
-            Some(5), 
+            "tor.service".to_owned(),
+            Some(5),
             None,
-            // Some("s=1b8c418e28534400856c27b211dd94fd;i=e067d;b=97571c13a1284f87bc0639b5cff5acbe;m=3b6a68a823;t=5ca4e2be1576e;x=9a6f65a5917f8e9f".to_owned()), 
-            // Some(true), 
-            None,
+            // Some("s=1b8c418e28534400856c27b211dd94fd;i=e067d;b=97571c13a1284f87bc0639b5cff5acbe;m=3b6a68a823;t=5ca4e2be1576e;x=9a6f65a5917f8e9f".to_owned()),
+            // Some(true),
+            false,
         )
         .await
         .unwrap()

--- a/appmgr/src/system.rs
+++ b/appmgr/src/system.rs
@@ -6,7 +6,8 @@ use rpc_toolkit::command;
 use tokio::process::Command;
 use tokio::sync::RwLock;
 
-use crate::context::RpcContext;
+use crate::context::{EitherContext, RpcContext};
+use crate::logs::{LogEntry, LogResponse};
 use crate::{Error, ErrorKind, ResultExt};
 
 pub const SYSTEMD_UNIT: &'static str = "embassyd";
@@ -17,45 +18,12 @@ fn parse_datetime(text: &str, _matches: &ArgMatches) -> Result<DateTime<Utc>, Er
 
 #[command(rpc_only)]
 pub async fn logs(
-    #[context] _ctx: RpcContext,
-    #[arg(parse(crate::system::parse_datetime))] before: Option<DateTime<Utc>>,
+    #[context] ctx: EitherContext,
     #[arg] limit: Option<usize>,
-) -> Result<Vec<(String, String)>, Error> {
-    let before = before.unwrap_or(Utc::now());
-    let limit = limit.unwrap_or(50);
-    // Journalctl has unexpected behavior where "until" does not play well with "lines" unless the output is reversed.
-    // Keep this in mind if you are changing the code below
-    let out = Command::new("journalctl")
-        .args(&[
-            "-u",
-            SYSTEMD_UNIT,
-            &format!(
-                "-U\"{} {} UTC\"",
-                before.date().naive_utc(),
-                before.time().format("%H:%M:%S")
-            ),
-            "--output=short-iso",
-            "--no-hostname",
-            "--utc",
-            "--reverse",
-            &format!("-n{}", limit),
-        ])
-        .output()
-        .await?
-        .stdout;
-    let out_string = String::from_utf8(out)?;
-    let lines = out_string.lines();
-    let mut split_lines = lines
-        .skip(1) // ditch the journalctl header
-        .map(|s| {
-            // split the timestamp off from the log line
-            let (ts, l) = s.split_once(" ").unwrap();
-            (ts.to_owned(), l.to_owned())
-        })
-        .collect::<Vec<(String, String)>>();
-    // reverse output again because we reversed it above
-    split_lines.reverse();
-    Ok(split_lines)
+    #[arg] cursor: Option<String>,
+    #[arg] reverse: Option<bool>,
+) -> Result<LogResponse, Error> {
+    Ok(crate::logs::logs(ctx, SYSTEMD_UNIT.to_owned(), limit, cursor, reverse).await?)
 }
 
 #[derive(serde::Serialize, Clone, Debug)]

--- a/appmgr/src/system.rs
+++ b/appmgr/src/system.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use rpc_toolkit::command;
 use tokio::sync::RwLock;
 
-use crate::context::{EitherContext, RpcContext};
+use crate::context::RpcContext;
 use crate::logs::{LogResponse, LogSource, fetch_logs};
 use crate::{Error, ErrorKind, ResultExt};
 
@@ -11,7 +11,7 @@ pub const SYSTEMD_UNIT: &'static str = "embassyd";
 
 #[command(rpc_only)]
 pub async fn logs(
-    #[context] ctx: EitherContext,
+    #[context] ctx: RpcContext,
     #[arg] limit: Option<usize>,
     #[arg] cursor: Option<String>,
     #[arg] before_flag: Option<bool>,


### PR DESCRIPTION
This PR implements the `package.logs` endpoint, and refactors the `system.logs` endpoint to use this new interface.

The call takes an `id`, a `limit`, a [journald-style] `cursor`, and a `before_flag`, and returns a `LogResponse`, which is an array of `LogEntry`s (themselves a `timestamp` and a `message`), a `start_cursor`, and an `end_cursor`.