### PR TITLE
Tor Key Pointers

### DIFF
--- a/appmgr/src/config/mod.rs
+++ b/appmgr/src/config/mod.rs
@@ -448,8 +448,8 @@ pub fn configure<'a, Db: DbHandle>(
 
                 // handle backreferences
                 for ptr in &dep_info.pointers {
-                    if let PackagePointerSpecVariant::Config { selector, multi } = ptr {
-                        if selector.select(*multi, &next) != selector.select(*multi, &prev) {
+                    if let PackagePointerSpecVariant::Config(cfg_ptr) = ptr {
+                        if cfg_ptr.select(&next) != cfg_ptr.select(&prev) {
                             if let Err(e) = configure(
                                 ctx, db, dependent, None, timeout, dry_run, overrides, breakages,
                             )

--- a/appmgr/src/config/spec.rs
+++ b/appmgr/src/config/spec.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use jsonpath_lib::Compiled as CompiledJsonPath;
+use lazy_static::__Deref;
 use patch_db::{DbHandle, OptionModel};
 use rand::{CryptoRng, Rng};
 use regex::Regex;
@@ -1501,93 +1502,40 @@ impl ValueSpec for ValueSpecPointer {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "target")]
 #[serde(rename_all = "kebab-case")]
-pub struct PackagePointerSpec {
-    pub package_id: PackageId,
-    #[serde(flatten)]
-    pub target: PackagePointerSpecVariant,
-}
-impl fmt::Display for PackagePointerSpec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", self.package_id, self.target)
-    }
+pub enum PackagePointerSpec {
+    TorAddress(TorAddressPointer),
+    LanAddress(LanAddressPointer),
+    Config(ConfigPointer),
 }
 impl PackagePointerSpec {
+    pub fn package_id(&self) -> &PackageId {
+        match self {
+            PackagePointerSpec::TorAddress(TorAddressPointer { package_id, .. }) => package_id,
+            PackagePointerSpec::LanAddress(LanAddressPointer { package_id, .. }) => package_id,
+            PackagePointerSpec::Config(ConfigPointer { package_id, .. }) => package_id,
+        }
+    }
     async fn deref<Db: DbHandle>(
         &self,
         ctx: &RpcContext,
         db: &mut Db,
         config_overrides: &BTreeMap<PackageId, Config>,
     ) -> Result<Value, ConfigurationError> {
-        match &self.target {
-            PackagePointerSpecVariant::Tor(TorAddressPointer { interface }) => {
-                let addr = crate::db::DatabaseModel::new()
-                    .package_data()
-                    .idx_model(&self.package_id)
-                    .and_then(|pde| pde.installed())
-                    .and_then(|installed| installed.interface_addresses().idx_model(interface))
-                    .and_then(|addresses| addresses.tor_address())
-                    .get(db, true)
-                    .await
-                    .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
-                Ok(addr.to_owned().map(Value::String).unwrap_or(Value::Null))
-            }
-            PackagePointerSpecVariant::Lan(LanAddressPointer { interface }) => {
-                let addr = crate::db::DatabaseModel::new()
-                    .package_data()
-                    .idx_model(&self.package_id)
-                    .and_then(|pde| pde.installed())
-                    .and_then(|installed| installed.interface_addresses().idx_model(interface))
-                    .and_then(|addresses| addresses.lan_address())
-                    .get(db, true)
-                    .await
-                    .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
-                Ok(addr.to_owned().map(Value::String).unwrap_or(Value::Null))
-            }
-            PackagePointerSpecVariant::Config(ConfigPointer { selector, multi }) => {
-                if let Some(cfg) = config_overrides.get(&self.package_id) {
-                    Ok(selector.select(*multi, &Value::Object(cfg.clone())))
-                } else {
-                    let manifest_model: OptionModel<Manifest> = crate::db::DatabaseModel::new()
-                        .package_data()
-                        .idx_model(&self.package_id)
-                        .and_then(|pde| pde.installed())
-                        .map(|installed| installed.manifest())
-                        .into();
-                    let version = manifest_model
-                        .clone()
-                        .map(|manifest| manifest.version())
-                        .get(db, true)
-                        .await
-                        .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
-                    let cfg_actions = manifest_model
-                        .clone()
-                        .and_then(|manifest| manifest.config())
-                        .get(db, true)
-                        .await
-                        .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
-                    let volumes = manifest_model
-                        .map(|manifest| manifest.volumes())
-                        .get(db, true)
-                        .await
-                        .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
-                    if let (Some(version), Some(cfg_actions), Some(volumes)) =
-                        (&*version, &*cfg_actions, &*volumes)
-                    {
-                        let cfg_res = cfg_actions
-                            .get(&ctx, &self.package_id, version, volumes)
-                            .await
-                            .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
-                        if let Some(cfg) = cfg_res.config {
-                            Ok(selector.select(*multi, &Value::Object(cfg)))
-                        } else {
-                            Ok(Value::Null)
-                        }
-                    } else {
-                        Ok(Value::Null)
-                    }
-                }
-            }
+        match &self {
+            PackagePointerSpec::TorAddress(tor) => tor.deref(db).await,
+            PackagePointerSpec::LanAddress(lan) => lan.deref(db).await,
+            PackagePointerSpec::Config(cfg) => cfg.deref(ctx, db, config_overrides).await,
+        }
+    }
+}
+impl fmt::Display for PackagePointerSpec {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PackagePointerSpec::TorAddress(tor) => write!(f, "{}", tor),
+            PackagePointerSpec::LanAddress(lan) => write!(f, "{}", lan),
+            PackagePointerSpec::Config(cfg) => write!(f, "{}", cfg),
         }
     }
 }
@@ -1607,13 +1555,14 @@ impl ValueSpec for PackagePointerSpec {
         Ok(())
     }
     fn validate(&self, manifest: &Manifest) -> Result<(), NoMatchWithPath> {
-        if manifest.id != self.package_id && !manifest.dependencies.0.contains_key(&self.package_id)
+        if &manifest.id != self.package_id()
+            && !manifest.dependencies.0.contains_key(self.package_id())
         {
             return Err(NoMatchWithPath::new(MatchError::InvalidPointer(
                 ValueSpecPointer::Package(self.clone()),
             )));
         }
-        match self.target {
+        match self {
             _ => Ok(()),
         }
     }
@@ -1633,7 +1582,7 @@ impl ValueSpec for PackagePointerSpec {
         Ok(pointers)
     }
     fn requires(&self, id: &PackageId, _value: &Value) -> bool {
-        &self.package_id == id
+        self.package_id() == id
     }
     fn eq(&self, _lhs: &Value, _rhs: &Value) -> bool {
         false
@@ -1641,48 +1590,70 @@ impl ValueSpec for PackagePointerSpec {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(tag = "target")]
 #[serde(rename_all = "kebab-case")]
-pub enum PackagePointerSpecVariant {
-    Tor(TorAddressPointer),
-    Lan(LanAddressPointer),
-    Config(ConfigPointer),
-}
-impl fmt::Display for PackagePointerSpecVariant {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Tor(tor) => write!(f, "{}", tor),
-            Self::Lan(lan) => write!(f, "{}", lan),
-            Self::Config(cfg) => write!(f, "{}", cfg),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TorAddressPointer {
+    package_id: PackageId,
     interface: InterfaceId,
+}
+impl TorAddressPointer {
+    async fn deref<Db: DbHandle>(&self, db: &mut Db) -> Result<Value, ConfigurationError> {
+        let addr = crate::db::DatabaseModel::new()
+            .package_data()
+            .idx_model(&self.package_id)
+            .and_then(|pde| pde.installed())
+            .and_then(|installed| installed.interface_addresses().idx_model(&self.interface))
+            .and_then(|addresses| addresses.tor_address())
+            .get(db, true)
+            .await
+            .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
+        Ok(addr.to_owned().map(Value::String).unwrap_or(Value::Null))
+    }
 }
 impl fmt::Display for TorAddressPointer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TorAddressPointer { interface } => write!(f, "tor-address: {}", interface),
+            TorAddressPointer {
+                package_id,
+                interface,
+            } => write!(f, "{}: tor-address: {}", package_id, interface),
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct LanAddressPointer {
+    package_id: PackageId,
     interface: InterfaceId,
 }
 impl fmt::Display for LanAddressPointer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LanAddressPointer { interface } => write!(f, "lan-address: {}", interface),
+            LanAddressPointer {
+                package_id,
+                interface,
+            } => write!(f, "{}: lan-address: {}", package_id, interface),
         }
     }
 }
+impl LanAddressPointer {
+    async fn deref<Db: DbHandle>(&self, db: &mut Db) -> Result<Value, ConfigurationError> {
+        let addr = crate::db::DatabaseModel::new()
+            .package_data()
+            .idx_model(&self.package_id)
+            .and_then(|pde| pde.installed())
+            .and_then(|installed| installed.interface_addresses().idx_model(&self.interface))
+            .and_then(|addresses| addresses.lan_address())
+            .get(db, true)
+            .await
+            .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
+        Ok(addr.to_owned().map(Value::String).unwrap_or(Value::Null))
+    }
+}
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct ConfigPointer {
+    package_id: PackageId,
     selector: Arc<ConfigSelector>,
     multi: bool,
 }
@@ -1690,11 +1661,64 @@ impl ConfigPointer {
     pub fn select(&self, val: &Value) -> Value {
         self.selector.select(self.multi, val)
     }
+    async fn deref<Db: DbHandle>(
+        &self,
+        ctx: &RpcContext,
+        db: &mut Db,
+        config_overrides: &BTreeMap<PackageId, Config>,
+    ) -> Result<Value, ConfigurationError> {
+        if let Some(cfg) = config_overrides.get(&self.package_id) {
+            Ok(self.select(&Value::Object(cfg.clone())))
+        } else {
+            let manifest_model: OptionModel<_> = crate::db::DatabaseModel::new()
+                .package_data()
+                .idx_model(&self.package_id)
+                .and_then(|pde| pde.installed())
+                .map(|installed| installed.manifest())
+                .into();
+            let version = manifest_model
+                .clone()
+                .map(|manifest| manifest.version())
+                .get(db, true)
+                .await
+                .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
+            let cfg_actions = manifest_model
+                .clone()
+                .and_then(|manifest| manifest.config())
+                .get(db, true)
+                .await
+                .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
+            let volumes = manifest_model
+                .map(|manifest| manifest.volumes())
+                .get(db, true)
+                .await
+                .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
+            if let (Some(version), Some(cfg_actions), Some(volumes)) =
+                (&*version, &*cfg_actions, &*volumes)
+            {
+                let cfg_res = cfg_actions
+                    .get(&ctx, &self.package_id, version, volumes)
+                    .await
+                    .map_err(|e| ConfigurationError::SystemError(Error::from(e)))?;
+                if let Some(cfg) = cfg_res.config {
+                    Ok(self.select(&Value::Object(cfg)))
+                } else {
+                    Ok(Value::Null)
+                }
+            } else {
+                Ok(Value::Null)
+            }
+        }
+    }
 }
 impl fmt::Display for ConfigPointer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ConfigPointer { selector, .. } => write!(f, "config: {}", selector),
+            ConfigPointer {
+                package_id,
+                selector,
+                ..
+            } => write!(f, "{}: config: {}", package_id, selector),
         }
     }
 }

--- a/appmgr/src/config/spec.rs
+++ b/appmgr/src/config/spec.rs
@@ -12,12 +12,12 @@ use async_trait::async_trait;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use jsonpath_lib::Compiled as CompiledJsonPath;
-use lazy_static::__Deref;
 use patch_db::{DbHandle, OptionModel};
 use rand::{CryptoRng, Rng};
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Number, Value};
+use sqlx::SqlitePool;
 
 use super::util::{self, CharSet, NumRange, UniqueBy, STATIC_NULL};
 use super::{Config, MatchError, NoMatchWithPath, TimeoutError, TypeOf};
@@ -41,6 +41,7 @@ pub trait ValueSpec {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError>;
@@ -156,10 +157,13 @@ where
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
-        self.inner.update(ctx, db, config_overrides, value).await
+        self.inner
+            .update(ctx, db, manifest, config_overrides, value)
+            .await
     }
     fn pointers(&self, value: &Value) -> Result<HashSet<ValueSpecPointer>, NoMatchWithPath> {
         self.inner.pointers(value)
@@ -197,10 +201,13 @@ where
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
-        self.inner.update(ctx, db, config_overrides, value).await
+        self.inner
+            .update(ctx, db, manifest, config_overrides, value)
+            .await
     }
     fn pointers(&self, value: &Value) -> Result<HashSet<ValueSpecPointer>, NoMatchWithPath> {
         self.inner.pointers(value)
@@ -271,10 +278,13 @@ where
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
-        self.inner.update(ctx, db, config_overrides, value).await
+        self.inner
+            .update(ctx, db, manifest, config_overrides, value)
+            .await
     }
     fn pointers(&self, value: &Value) -> Result<HashSet<ValueSpecPointer>, NoMatchWithPath> {
         self.inner.pointers(value)
@@ -382,18 +392,19 @@ impl ValueSpec for ValueSpecAny {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
         match self {
-            ValueSpecAny::Boolean(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecAny::Enum(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecAny::List(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecAny::Number(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecAny::Object(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecAny::String(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecAny::Union(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecAny::Pointer(a) => a.update(ctx, db, config_overrides, value).await,
+            ValueSpecAny::Boolean(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecAny::Enum(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecAny::List(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecAny::Number(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecAny::Object(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecAny::String(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecAny::Union(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecAny::Pointer(a) => a.update(ctx, db, manifest, config_overrides, value).await,
         }
     }
     fn pointers(&self, value: &Value) -> Result<HashSet<ValueSpecPointer>, NoMatchWithPath> {
@@ -473,8 +484,9 @@ impl ValueSpec for ValueSpecBoolean {
     }
     async fn update<Db: DbHandle>(
         &self,
-        ctx: &RpcContext,
+        _ctx: &RpcContext,
         _db: &mut Db,
+        _manifest: &Manifest,
         _config_overrides: &BTreeMap<PackageId, Config>,
         _value: &mut Value,
     ) -> Result<(), ConfigurationError> {
@@ -561,8 +573,9 @@ impl ValueSpec for ValueSpecEnum {
     }
     async fn update<Db: DbHandle>(
         &self,
-        ctx: &RpcContext,
+        _ctx: &RpcContext,
         _db: &mut Db,
+        _manifest: &Manifest,
         _config_overrides: &BTreeMap<PackageId, Config>,
         _value: &mut Value,
     ) -> Result<(), ConfigurationError> {
@@ -648,12 +661,17 @@ where
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
         if let Value::Array(ref mut ls) = value {
             for (i, val) in ls.into_iter().enumerate() {
-                match self.spec.update(ctx, db, config_overrides, val).await {
+                match self
+                    .spec
+                    .update(ctx, db, manifest, config_overrides, val)
+                    .await
+                {
                     Err(ConfigurationError::NoMatch(e)) => {
                         Err(ConfigurationError::NoMatch(e.prepend(format!("{}", i))))
                     }
@@ -750,15 +768,16 @@ impl ValueSpec for ValueSpecList {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
         match self {
-            ValueSpecList::Enum(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecList::Number(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecList::Object(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecList::String(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecList::Union(a) => a.update(ctx, db, config_overrides, value).await,
+            ValueSpecList::Enum(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecList::Number(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecList::Object(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecList::String(a) => a.update(ctx, db, manifest, config_overrides, value).await,
+            ValueSpecList::Union(a) => a.update(ctx, db, manifest, config_overrides, value).await,
         }
     }
     fn pointers(&self, value: &Value) -> Result<HashSet<ValueSpecPointer>, NoMatchWithPath> {
@@ -871,8 +890,9 @@ impl ValueSpec for ValueSpecNumber {
     }
     async fn update<Db: DbHandle>(
         &self,
-        ctx: &RpcContext,
+        _ctx: &RpcContext,
         _db: &mut Db,
+        _manifest: &Manifest,
         _config_overrides: &BTreeMap<PackageId, Config>,
         _value: &mut Value,
     ) -> Result<(), ConfigurationError> {
@@ -935,11 +955,14 @@ impl ValueSpec for ValueSpecObject {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
         if let Value::Object(o) = value {
-            self.spec.update(ctx, db, config_overrides, o).await
+            self.spec
+                .update(ctx, db, manifest, config_overrides, o)
+                .await
         } else {
             Err(ConfigurationError::NoMatch(NoMatchWithPath::new(
                 MatchError::InvalidType("object", value.type_of()),
@@ -1034,6 +1057,7 @@ impl ConfigSpec {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         cfg: &mut Config,
     ) -> Result<(), ConfigurationError> {
@@ -1041,10 +1065,11 @@ impl ConfigSpec {
             match cfg.get_mut(k) {
                 None => {
                     let mut v = Value::Null;
-                    vs.update(ctx, db, config_overrides, &mut v).await?;
+                    vs.update(ctx, db, manifest, config_overrides, &mut v)
+                        .await?;
                     cfg.insert(k.clone(), v);
                 }
-                Some(v) => match vs.update(ctx, db, config_overrides, v).await {
+                Some(v) => match vs.update(ctx, db, manifest, config_overrides, v).await {
                     Err(ConfigurationError::NoMatch(e)) => {
                         Err(ConfigurationError::NoMatch(e.prepend(k.clone())))
                     }
@@ -1124,8 +1149,9 @@ impl ValueSpec for ValueSpecString {
     }
     async fn update<Db: DbHandle>(
         &self,
-        ctx: &RpcContext,
+        _ctx: &RpcContext,
         _db: &mut Db,
+        _manifest: &Manifest,
         _config_overrides: &BTreeMap<PackageId, Config>,
         _value: &mut Value,
     ) -> Result<(), ConfigurationError> {
@@ -1336,6 +1362,7 @@ impl ValueSpec for ValueSpecUnion {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
@@ -1348,7 +1375,7 @@ impl ValueSpec for ValueSpecUnion {
                     None => Err(ConfigurationError::NoMatch(NoMatchWithPath::new(
                         MatchError::Union(tag.clone(), self.variants.keys().cloned().collect()),
                     ))),
-                    Some(spec) => spec.update(ctx, db, config_overrides, o).await,
+                    Some(spec) => spec.update(ctx, db, manifest, config_overrides, o).await,
                 },
                 Some(other) => Err(ConfigurationError::NoMatch(
                     NoMatchWithPath::new(MatchError::InvalidType("string", other.type_of()))
@@ -1477,12 +1504,17 @@ impl ValueSpec for ValueSpecPointer {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
         match self {
-            ValueSpecPointer::Package(a) => a.update(ctx, db, config_overrides, value).await,
-            ValueSpecPointer::System(a) => a.update(ctx, db, config_overrides, value).await,
+            ValueSpecPointer::Package(a) => {
+                a.update(ctx, db, manifest, config_overrides, value).await
+            }
+            ValueSpecPointer::System(a) => {
+                a.update(ctx, db, manifest, config_overrides, value).await
+            }
         }
     }
     fn pointers(&self, _value: &Value) -> Result<HashSet<ValueSpecPointer>, NoMatchWithPath> {
@@ -1505,6 +1537,7 @@ impl ValueSpec for ValueSpecPointer {
 #[serde(tag = "target")]
 #[serde(rename_all = "kebab-case")]
 pub enum PackagePointerSpec {
+    TorKey(TorKeyPointer),
     TorAddress(TorAddressPointer),
     LanAddress(LanAddressPointer),
     Config(ConfigPointer),
@@ -1512,6 +1545,7 @@ pub enum PackagePointerSpec {
 impl PackagePointerSpec {
     pub fn package_id(&self) -> &PackageId {
         match self {
+            PackagePointerSpec::TorKey(TorKeyPointer { package_id, .. }) => package_id,
             PackagePointerSpec::TorAddress(TorAddressPointer { package_id, .. }) => package_id,
             PackagePointerSpec::LanAddress(LanAddressPointer { package_id, .. }) => package_id,
             PackagePointerSpec::Config(ConfigPointer { package_id, .. }) => package_id,
@@ -1521,9 +1555,11 @@ impl PackagePointerSpec {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
     ) -> Result<Value, ConfigurationError> {
         match &self {
+            PackagePointerSpec::TorKey(key) => key.deref(&manifest.id, &ctx.secret_store).await,
             PackagePointerSpec::TorAddress(tor) => tor.deref(db).await,
             PackagePointerSpec::LanAddress(lan) => lan.deref(db).await,
             PackagePointerSpec::Config(cfg) => cfg.deref(ctx, db, config_overrides).await,
@@ -1533,6 +1569,7 @@ impl PackagePointerSpec {
 impl fmt::Display for PackagePointerSpec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            PackagePointerSpec::TorKey(key) => write!(f, "{}", key),
             PackagePointerSpec::TorAddress(tor) => write!(f, "{}", tor),
             PackagePointerSpec::LanAddress(lan) => write!(f, "{}", lan),
             PackagePointerSpec::Config(cfg) => write!(f, "{}", cfg),
@@ -1570,10 +1607,11 @@ impl ValueSpec for PackagePointerSpec {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        manifest: &Manifest,
         config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {
-        *value = self.deref(ctx, db, config_overrides).await?;
+        *value = self.deref(ctx, db, manifest, config_overrides).await?;
         Ok(())
     }
     fn pointers(&self, _value: &Value) -> Result<HashSet<ValueSpecPointer>, NoMatchWithPath> {
@@ -1670,7 +1708,7 @@ impl ConfigPointer {
         if let Some(cfg) = config_overrides.get(&self.package_id) {
             Ok(self.select(&Value::Object(cfg.clone())))
         } else {
-            let manifest_model: OptionModel<_> = crate::db::DatabaseModel::new()
+            let manifest_model: OptionModel<Manifest> = crate::db::DatabaseModel::new()
                 .package_data()
                 .idx_model(&self.package_id)
                 .and_then(|pde| pde.installed())
@@ -1776,6 +1814,44 @@ impl Hash for ConfigSelector {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(tag = "target")]
+pub struct TorKeyPointer {
+    package_id: PackageId,
+    interface: InterfaceId,
+}
+impl TorKeyPointer {
+    async fn deref(
+        &self,
+        source_package: &PackageId,
+        secrets: &SqlitePool,
+    ) -> Result<Value, ConfigurationError> {
+        if &self.package_id != source_package {
+            return Err(ConfigurationError::PermissionDenied(
+                ValueSpecPointer::Package(PackagePointerSpec::TorKey(self.clone())),
+            ));
+        }
+        let x = sqlx::query!(
+            "SELECT key FROM tor WHERE package = ? AND interface = ?",
+            *self.package_id,
+            *self.interface
+        )
+        .fetch_one(secrets)
+        .await
+        .map_err(|e| ConfigurationError::SystemError(e.into()))?;
+        Ok(Value::String(base32::encode(
+            base32::Alphabet::RFC4648 { padding: false },
+            &x.key,
+        )))
+    }
+}
+impl fmt::Display for TorKeyPointer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: tor-key: {}", self.package_id, self.interface)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(tag = "target")]
 pub enum SystemPointerSpec {}
 impl fmt::Display for SystemPointerSpec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1809,6 +1885,7 @@ impl ValueSpec for SystemPointerSpec {
         &self,
         ctx: &RpcContext,
         db: &mut Db,
+        _manifest: &Manifest,
         _config_overrides: &BTreeMap<PackageId, Config>,
         value: &mut Value,
     ) -> Result<(), ConfigurationError> {

--- a/appmgr/src/db/model.rs
+++ b/appmgr/src/db/model.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use torut::onion::TorSecretKeyV3;
 
-use crate::config::spec::{PackagePointerSpecVariant, SystemPointerSpec};
+use crate::config::spec::{PackagePointerSpec, SystemPointerSpec};
 use crate::install::progress::InstallProgress;
 use crate::net::interface::InterfaceId;
 use crate::s9pk::manifest::{Manifest, ManifestModel, PackageId};
@@ -235,7 +235,7 @@ pub struct StaticDependencyInfo {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, HasModel)]
 #[serde(rename_all = "kebab-case")]
 pub struct CurrentDependencyInfo {
-    pub pointers: Vec<PackagePointerSpecVariant>,
+    pub pointers: Vec<PackagePointerSpec>,
     pub health_checks: BTreeSet<HealthCheckId>,
 }
 

--- a/appmgr/src/s9pk/manifest.rs
+++ b/appmgr/src/s9pk/manifest.rs
@@ -102,6 +102,7 @@ where
 pub struct Manifest {
     pub id: PackageId,
     pub title: String,
+    #[model]
     pub version: Version,
     pub description: Description,
     #[serde(default)]

--- a/appmgr/src/volume.rs
+++ b/appmgr/src/volume.rs
@@ -128,6 +128,7 @@ impl Map for Volumes {
         self.0.get(key)
     }
 }
+pub type VolumesModel = MapModel<Volumes>;
 impl HasModel for Volumes {
     type Model = MapModel<Self>;
 }


### PR DESCRIPTION
This PR:
1. Changes pointer enumeration to a Set instead of a Vec
2. Collapses the PackagePointerSpec to a single enum, moving the package_id to a row on each arm
3. Gives the constituent arms a single argument constructor over a unique pointer type
4. Adds a TorKey pointer type
5. Adds permission checking to dereference logic for the TorKey
6. Threads new requirements through the deref logic

It does not refactor the means of config dereference traversal. It also doesn't remove the `validate` call from the ValueSpec trait.