### PR TITLE
drive capacity disable

### DIFF
--- a/setup-wizard/src/app/pages/embassy/embassy.page.html
+++ b/setup-wizard/src/app/pages/embassy/embassy.page.html
@@ -35,11 +35,16 @@
                 </ion-item>
               </ng-container>
               <ng-container *ngIf="storageDrives.length">
-                <ion-item (click)="chooseDrive(drive)" class="ion-margin-bottom" button lines="none" *ngFor="let drive of storageDrives">
+                <ion-item (click)="chooseDrive(drive)" class="ion-margin-bottom" button lines="none" *ngFor="let drive of storageDrives" [disabled]="drive.capacity < 100000">
                   <ion-icon slot="start" name="save-outline"></ion-icon>
                   <ion-label class="ion-text-wrap">
                     <h1>{{ drive.vendor || 'Unknown Vendor' }} - {{ drive.model || 'Unknown Model' }}</h1>
                     <h2>{{ drive.logicalname }} - {{ drive.capacity | convertBytes }}</h2>
+                    <p *ngIf="drive.capacity < 100000">
+                      <ion-text>
+                        Drive capacity too small.
+                      </ion-text>
+                    </p>
                   </ion-label>
                 </ion-item>
               </ng-container>

--- a/setup-wizard/src/app/pages/embassy/embassy.page.html
+++ b/setup-wizard/src/app/pages/embassy/embassy.page.html
@@ -35,12 +35,12 @@
                 </ion-item>
               </ng-container>
               <ng-container *ngIf="storageDrives.length">
-                <ion-item (click)="chooseDrive(drive)" class="ion-margin-bottom" button lines="none" *ngFor="let drive of storageDrives" [disabled]="drive.capacity < 100000">
+                <ion-item (click)="chooseDrive(drive)" class="ion-margin-bottom" button lines="none" *ngFor="let drive of storageDrives" [disabled]="drive.capacity < 34359738368">
                   <ion-icon slot="start" name="save-outline"></ion-icon>
                   <ion-label class="ion-text-wrap">
                     <h1>{{ drive.vendor || 'Unknown Vendor' }} - {{ drive.model || 'Unknown Model' }}</h1>
                     <h2>{{ drive.logicalname }} - {{ drive.capacity | convertBytes }}</h2>
-                    <p *ngIf="drive.capacity < 100000">
+                    <p *ngIf="drive.capacity < 34359738368">
                       <ion-text>
                         Drive capacity too small.
                       </ion-text>

--- a/setup-wizard/src/app/services/api/mock-api.service.ts
+++ b/setup-wizard/src/app/services/api/mock-api.service.ts
@@ -54,7 +54,7 @@ export class MockApiService extends ApiService {
         model: 'Model',
         logicalname: 'dev/sdb',
         partitions: [],
-        capacity: 1600.01234,
+        capacity: 34359738369,
         guid: null,
       },
       {


### PR DESCRIPTION
Disable selecting an embassy drive in the wizard if less than 32 gb