### PR TITLE
feature/unstable

### DIFF
--- a/appmgr/Cargo.toml
+++ b/appmgr/Cargo.toml
@@ -41,6 +41,7 @@ avahi = ["avahi-sys"]
 default = ["avahi", "sound", "metal"]
 metal = []
 sound = []
+unstable = ["patch-db/unstable"]
 
 [dependencies]
 aes = { version = "0.7.5", features = ["ctr"] }

--- a/appmgr/build-prod.sh
+++ b/appmgr/build-prod.sh
@@ -11,6 +11,10 @@ fi
 alias 'rust-arm64-builder'='docker run --rm -it -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-arm-cross:aarch64'
 
 cd ..
-rust-arm64-builder sh -c "(cd appmgr && cargo build --release)"
+if [[ "$ENVIRONMENT" =~ (^|-)unstable($|-) ]]; then
+	rust-arm64-builder sh -c "(cd appmgr && cargo build --release --features unstable)"
+else
+	rust-arm64-builder sh -c "(cd appmgr && cargo build --release)"
+fi
 cd appmgr
 #rust-arm64-builder aarch64-linux-gnu-strip target/aarch64-unknown-linux-gnu/release/embassyd

--- a/appmgr/src/context/rpc.rs
+++ b/appmgr/src/context/rpc.rs
@@ -370,9 +370,10 @@ impl Context for RpcContext {
 impl Deref for RpcContext {
     type Target = RpcContextSeed;
     fn deref(&self) -> &Self::Target {
+        #[cfg(feature = "unstable")]
         if self.0.is_closed.load(Ordering::SeqCst) {
             panic!(
-                "RpcContext used after shutdown! {:?}",
+                "RpcContext used after shutdown! {}",
                 tracing_error::SpanTrace::capture()
             );
         }

--- a/appmgr/src/dependencies.rs
+++ b/appmgr/src/dependencies.rs
@@ -6,7 +6,7 @@ use color_eyre::eyre::eyre;
 use emver::VersionRange;
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use patch_db::{DbHandle, HasModel, Map, MapModel, PatchDbHandle};
+use patch_db::{DbHandle, HasModel, LockType, Map, MapModel, PatchDbHandle};
 use rand::SeedableRng;
 use rpc_toolkit::command;
 use serde::{Deserialize, Serialize};
@@ -535,6 +535,10 @@ pub async fn configure_logic(
     db: &mut PatchDbHandle,
     (pkg_id, dependency_id): (PackageId, PackageId),
 ) -> Result<ConfigDryRes, Error> {
+    crate::db::DatabaseModel::new()
+        .package_data()
+        .lock(db, LockType::Read)
+        .await?;
     let pkg_model = crate::db::DatabaseModel::new()
         .package_data()
         .idx_model(&pkg_id)

--- a/appmgr/src/disk/mount/filesystem/cifs.rs
+++ b/appmgr/src/disk/mount/filesystem/cifs.rs
@@ -3,7 +3,6 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
-use color_eyre::eyre::eyre;
 use digest::generic_array::GenericArray;
 use digest::Digest;
 use serde::{Deserialize, Serialize};
@@ -48,14 +47,8 @@ pub async fn mount_cifs(
     Command::new("mount")
         .arg("-t")
         .arg("cifs")
-        .arg("-o")
-        .arg(format!(
-            "username={}{}",
-            username,
-            password
-                .map(|p| format!(",password={}", p))
-                .unwrap_or_default()
-        ))
+        .env("USER", username)
+        .env("PASSWD", password.unwrap_or_default())
         .arg(format!("//{}{}", ip, absolute_path.display()))
         .arg(mountpoint.as_ref())
         .invoke(crate::ErrorKind::Filesystem)

--- a/appmgr/src/manager/health.rs
+++ b/appmgr/src/manager/health.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use patch_db::DbHandle;
+use patch_db::{DbHandle, LockType};
 use tracing::instrument;
 
 use crate::context::RpcContext;
@@ -63,6 +63,11 @@ pub async fn check<Db: DbHandle>(
     }
 
     let mut checkpoint = tx.begin().await?;
+
+    crate::db::DatabaseModel::new()
+        .package_data()
+        .lock(&mut checkpoint, LockType::Write)
+        .await?;
 
     let mut status = crate::db::DatabaseModel::new()
         .package_data()

--- a/build/write-image.sh
+++ b/build/write-image.sh
@@ -64,7 +64,7 @@ sudo cp -R diagnostic-ui/www /tmp/eos-mnt/var/www/html/diagnostic
 # Make the .ssh directory
 sudo mkdir -p /tmp/eos-mnt/root/.ssh
 
-if [ "$ENVIRONMENT" = "dev" ]; then
+if [[ "$ENVIRONMENT" =~ (^|-)dev($|-) ]]; then
 	cat ./build/initialization.sh | grep -v "passwd -l ubuntu" | sudo tee /tmp/eos-mnt/usr/local/bin/initialization.sh > /dev/null
 	sudo chmod +x /tmp/eos-mnt/usr/local/bin/initialization.sh
 else


### PR DESCRIPTION
adds feature flag `unstable` for throwing errors that will help find potential bad behavior but is dangerous to leave on in the wild

to enable, include `unstable` in the `ENVIRONMENT` env var during build.
i.e. `ENVIRONMENT=dev-unstable make`