### PR TITLE
Bugfix/boot cleanup

### DIFF
--- a/appmgr/src/context/rpc.rs
+++ b/appmgr/src/context/rpc.rs
@@ -309,7 +309,7 @@ impl RpcContext {
                     .idx_model(&package_id)
                     .get_mut(&mut db)
                     .await?;
-                match pde.as_ref_mut().ok_or_else(|| {
+                match pde.as_mut().ok_or_else(|| {
                     Error::new(
                         eyre!("Node does not exist: /package-data/{}", package_id),
                         crate::ErrorKind::Database,
@@ -332,7 +332,7 @@ impl RpcContext {
                         ..
                     } => {
                         let new_main = match std::mem::replace(
-                            &mut main,
+                            main,
                             MainStatus::Stopped, /* placeholder */
                         ) {
                             MainStatus::BackingUp { started, health } => {

--- a/appmgr/src/context/rpc.rs
+++ b/appmgr/src/context/rpc.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bollard::Docker;
+use color_eyre::eyre::eyre;
 use patch_db::json_ptr::JsonPointer;
 use patch_db::{DbHandle, PatchDb, Revision};
 use reqwest::Url;
@@ -306,11 +307,14 @@ impl RpcContext {
                 let mut pde = crate::db::DatabaseModel::new()
                     .package_data()
                     .idx_model(&package_id)
-                    .expect(&mut db)
-                    .await?
                     .get_mut(&mut db)
                     .await?;
-                match &mut *pde {
+                match pde.as_ref_mut().ok_or_else(|| {
+                    Error::new(
+                        eyre!("Node does not exist: /package-data/{}", package_id),
+                        crate::ErrorKind::Database,
+                    )
+                })? {
                     PackageDataEntry::Installing { .. }
                     | PackageDataEntry::Restoring { .. }
                     | PackageDataEntry::Updating { .. } => {

--- a/appmgr/src/context/rpc.rs
+++ b/appmgr/src/context/rpc.rs
@@ -332,7 +332,7 @@ impl RpcContext {
                         ..
                     } => {
                         let new_main = match std::mem::replace(
-                            main,
+                            &mut main,
                             MainStatus::Stopped, /* placeholder */
                         ) {
                             MainStatus::BackingUp { started, health } => {


### PR DESCRIPTION
Fixes the following error when booting up with a service stuck in finalizing state. Part of debugging linked issue:

```
Jan 03 22:19:29 embassy-398ecc0f embassyd[5276]:    0: Invalid Lock Request: Lock Type Escalation: Session = HandleId { id: 1, trace: Some(SpanTrace [{ target: "embassy::context::rpc", name: "cleanup", file: "src/context/rpc.rs", line: 297 }]) }, Pointer = /package-data/thunderhub, First = E, Second = W
Jan 03 22:19:29 embassy-398ecc0f embassyd[5276]:    1: Lock Type Escalation: Session = HandleId { id: 1, trace: Some(SpanTrace [{ target: "embassy::context::rpc", name: "cleanup", file: "src/context/rpc.rs", line: 297 }]) }, Pointer = /package-data/thunderhub, First = E, Second = W
Jan 03 22:19:29 embassy-398ecc0f embassyd[5276]: Location:
Jan 03 22:19:29 embassy-398ecc0f embassyd[5276]:    /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/convert/mod.rs:542
Jan 03 22:19:29 embassy-398ecc0f embassyd[5276]:   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Jan 03 22:19:29 embassy-398ecc0f embassyd[5276]:    0: embassy::context::rpc::cleanup
Jan 03 22:19:29 embassy-398ecc0f embassyd[5276]:       at src/context/rpc.rs:297