### PR TITLE
adds support for no product key builds as well as chosen product key …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 
 eos.img: $(EMBASSY_SRC) system-images/compat/compat.tar system-images/utils/utils.tar
 	! test -f eos.img || rm eos.img
-	./build/make-image.sh
+	if [ $(NO_KEY) -eq 1 ]; then NO_KEY=1 ./build/make-image.sh; else ./build/make-image.sh; fi
 
 system-images/compat/compat.tar: $(COMPAT_SRC)
 	cd system-images/compat && ./build.sh
@@ -51,6 +51,7 @@ ubuntu.img:
 product_key.txt:
 	$(shell which echo) -n "X" > product_key.txt
 	cat /dev/urandom | base32 | head -c11 | tr '[:upper:]' '[:lower:]' >> product_key.txt
+	if [ "$(KEY)" != "" ]; then $(shell which echo) -n "$(KEY)" > product_key.txt; fi
 	echo >> product_key.txt
 
 $(EMBASSY_BINS): $(APPMGR_SRC)

--- a/build/write-image.sh
+++ b/build/write-image.sh
@@ -33,7 +33,7 @@ sudo mv /tmp/eos-mnt/config.txt.tmp /tmp/eos-mnt/config.txt
 # Unmount the boot partition and mount embassy partition
 sudo umount /tmp/eos-mnt
 sudo mount ${OUTPUT_DEVICE}p2 /tmp/eos-mnt
-sudo cp product_key.txt /tmp/eos-mnt
+if [ "$NO_KEY" != "1" ]; then sudo cp product_key.txt /tmp/eos-mnt; else echo "This image is being written with no product key"; fi
 sudo umount /tmp/eos-mnt
 
 sudo mount ${OUTPUT_DEVICE}p3 /tmp/eos-mnt


### PR DESCRIPTION
…builds

This stemmed from the observation that we need to support no product keys on the device for the 02x update recovery path. You may no build eos as so:

`make KEY=thekeyiwant`
OR
`make NO_KEY=1`

the former syntax is chosen key, the latter is no key.