### PR TITLE
removed broken packages entry in patchdb

### DIFF
--- a/appmgr/src/db/model.rs
+++ b/appmgr/src/db/model.rs
@@ -29,7 +29,6 @@ pub struct Database {
     pub package_data: AllPackageData,
     #[model]
     pub recovered_packages: BTreeMap<PackageId, RecoveredPackageInfo>,
-    pub broken_packages: Vec<PackageId>,
     pub ui: Value,
 }
 impl Database {
@@ -70,7 +69,6 @@ impl Database {
             },
             package_data: AllPackageData::default(),
             recovered_packages: BTreeMap::new(),
-            broken_packages: Vec::new(),
             ui: Value::Object(Default::default()),
         }
     }

--- a/appmgr/src/install/mod.rs
+++ b/appmgr/src/install/mod.rs
@@ -546,7 +546,6 @@ pub async fn install_s9pk_or_cleanup<R: AsyncRead + AsyncSeek + Unpin>(
         let mut tx = handle.begin().await?;
 
         if let Err(e) = cleanup_failed(&ctx, &mut tx, pkg_id).await {
-            let mut tx = handle.begin().await?;
             tracing::error!(
                 "Failed to clean up {}@{}: {}: Adding to broken packages",
                 pkg_id,
@@ -554,13 +553,6 @@ pub async fn install_s9pk_or_cleanup<R: AsyncRead + AsyncSeek + Unpin>(
                 e
             );
             tracing::debug!("{:?}", e);
-            let mut broken = crate::db::DatabaseModel::new()
-                .broken_packages()
-                .get_mut(&mut tx)
-                .await?;
-            broken.push(pkg_id.clone());
-            broken.save(&mut tx).await?;
-            tx.commit(None).await?;
         } else {
             tx.commit(None).await?;
         }


### PR DESCRIPTION
No ticket.
This is to address an instance of non-canonical lock ordering. We realized that this value, while written to, is never read and therefore not needed.