### PR TITLE
Bugfix/nginx registry dependence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 
 eos.img: $(EMBASSY_SRC) system-images/compat/compat.tar system-images/utils/utils.tar
 	! test -f eos.img || rm eos.img
-	if [ $(NO_KEY) = 1 ]; then NO_KEY=1 ./build/make-image.sh; else ./build/make-image.sh; fi
+	if [ "$(NO_KEY)" = "1" ]; then NO_KEY=1 ./build/make-image.sh; else ./build/make-image.sh; fi
 
 system-images/compat/compat.tar: $(COMPAT_SRC)
 	cd system-images/compat && ./build.sh

--- a/appmgr/src/nginx/main-ui.conf.template
+++ b/appmgr/src/nginx/main-ui.conf.template
@@ -46,11 +46,15 @@ server {{
         }}
 
         location /marketplace/eos/ {{
-                proxy_pass {eos_marketplace}/eos/;
+                # ns1.digitalocean.com, ns2.digitalocean.com, ns3.digitalocean.com
+                resolver 173.245.58.51 173.245.59.41 198.41.222.173;
+                proxy_pass {eos_marketplace}eos/;
         }}
 
         location /marketplace/package/ {{
-                proxy_pass {package_marketplace}/package/;
+                # ns1.digitalocean.com, ns2.digitalocean.com, ns3.digitalocean.com
+                resolver 173.245.58.51 173.245.59.41 198.41.222.173;
+                proxy_pass {package_marketplace}package/;
         }}
 
         location / {{
@@ -107,8 +111,16 @@ server {{
                 proxy_pass http://127.0.0.1:5961/;
         }}
 
-        location /marketplace/ {{
-                proxy_pass {package_marketplace}/;
+        location /marketplace/eos/ {{
+                # ns1.digitalocean.com, ns2.digitalocean.com, ns3.digitalocean.com
+                resolver 173.245.58.51 173.245.59.41 198.41.222.173;
+                proxy_pass {eos_marketplace}eos/;
+        }}
+        
+        location /marketplace/package/ {{
+                # ns1.digitalocean.com, ns2.digitalocean.com, ns3.digitalocean.com
+                resolver 173.245.58.51 173.245.59.41 198.41.222.173;
+                proxy_pass {package_marketplace}package/;
         }}
 
         location / {{


### PR DESCRIPTION
There's no ticket for this but the issue that it solves is that currently if the registry is down when nginx starts up, nginx will dramatically die because it can't resolve the DNS for the registry url. Adding a resolver allows it to survive non-resolution on startup and defer DNS lookup to runtime, it will cache the entry by default so it should not cause pervasive latency. The nameservers I chose are the ones that host start9labs.com and start9.com. We can add as many as we want here, so if the choice of the 3 digital ocean nameservers isn't enough we can add more.