### PR TITLE
Fix/show errors

### DIFF
--- a/appmgr/src/net/wifi.rs
+++ b/appmgr/src/net/wifi.rs
@@ -69,22 +69,21 @@ pub async fn add(
         drop(wpa_supplicant);
         Ok(())
     }
-    tokio::spawn(async move {
-        match add_procedure(
-            &mut ctx.db.handle(),
-            ctx.wifi_manager.clone(),
-            &Ssid(ssid.clone()),
-            &Psk(password.clone()),
-            priority,
-        )
-        .await
-        {
-            Err(e) => {
-                tracing::info!("Failed to add new WiFi network '{}': {}", ssid, e);
-            }
-            Ok(_) => {}
-        }
-    });
+    if let Err(err) = add_procedure(
+        &mut ctx.db.handle(),
+        ctx.wifi_manager.clone(),
+        &Ssid(ssid.clone()),
+        &Psk(password.clone()),
+        priority,
+    )
+    .await
+    {
+        tracing::error!("Failed to add new WiFi network '{}': {}", ssid, e);
+        return Err(Error::new(
+            color_eyre::eyre::eyre!("Failed adding {}", ssid),
+            ErrorKind::Wifi,
+        ));
+    }
     Ok(())
 }
 
@@ -122,20 +121,20 @@ pub async fn connect(#[context] ctx: RpcContext, #[arg] ssid: String) -> Result<
         }
         Ok(())
     }
-    tokio::spawn(async move {
-        match connect_procedure(
-            &mut ctx.db.handle(),
-            ctx.wifi_manager.clone(),
-            &Ssid(ssid.clone()),
-        )
-        .await
-        {
-            Err(e) => {
-                tracing::info!("Failed to connect to WiFi network '{}': {}", &ssid, e);
-            }
-            Ok(_) => {}
-        }
-    });
+
+    if let Err(err) = connect_procedure(
+        &mut ctx.db.handle(),
+        ctx.wifi_manager.clone(),
+        &Ssid(ssid.clone()),
+    )
+    .await
+    {
+        tracing::error!("Failed to connect to WiFi network '{}': {}", &ssid, err);
+        return Err(Error::new(
+            color_eyre::eyre::eyre!("Can't connect to {}", ssid),
+            ErrorKind::Wifi,
+        ));
+    }
     Ok(())
 }
 

--- a/appmgr/src/net/wifi.rs
+++ b/appmgr/src/net/wifi.rs
@@ -78,7 +78,7 @@ pub async fn add(
     )
     .await
     {
-        tracing::error!("Failed to add new WiFi network '{}': {}", ssid, e);
+        tracing::error!("Failed to add new WiFi network '{}': {}", ssid, err);
         return Err(Error::new(
             color_eyre::eyre::eyre!("Failed adding {}", ssid),
             ErrorKind::Wifi,


### PR DESCRIPTION
So, the errors that happen don't show in the front end, and it should. Don't know why it was running in a spawn, but it shouldn't and now we can see the errors.

This was a quick life quality that @kn0wmad was running into and I believe that this should be showing that something didn't work.
