### PR TITLE
add protocol header for proxied services

### DIFF
--- a/appmgr/src/net/nginx.conf.template
+++ b/appmgr/src/net/nginx.conf.template
@@ -7,6 +7,7 @@ server {{
     location / {{
         proxy_pass http://{app_ip}:{internal_port}/;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 0;
         proxy_request_buffering off;
         proxy_buffering off;


### PR DESCRIPTION
Discovered as a result of visiting btcpay on .local over https:

`BTCPay is expecting you to access this website from http://<REDACTED>.local/. If you use a reverse proxy, please set the X-Forwarded-Proto header to https`