### PR TITLE
fix issues with failed updates

### DIFF
--- a/backend/src/sound.rs
+++ b/backend/src/sound.rs
@@ -40,7 +40,9 @@ impl SoundInterface {
         let instant = Instant::now();
         while tokio::fs::metadata(&*PERIOD_FILE).await.is_err()
             && instant.elapsed() < Duration::from_secs(1)
-        {}
+        {
+            tokio::time::sleep(Duration::from_millis(1));
+        }
         Ok(SoundInterface(Some(guard)))
     }
     #[instrument(skip(self))]

--- a/backend/src/sound.rs
+++ b/backend/src/sound.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use divrem::DivRem;
 use proptest_derive::Arbitrary;
@@ -37,6 +37,10 @@ impl SoundInterface {
                 }
             })
             .with_ctx(|_| (ErrorKind::SoundError, EXPORT_FILE.to_string_lossy()))?;
+        let instant = Instant::now();
+        while tokio::fs::metadata(&*PERIOD_FILE).await.is_err()
+            && instant.elapsed() < Duration::from_secs(1)
+        {}
         Ok(SoundInterface(Some(guard)))
     }
     #[instrument(skip(self))]

--- a/build/rip-image.sh
+++ b/build/rip-image.sh
@@ -93,3 +93,6 @@ if ! [[ "$(cat $INPUT_HASH)" == "$(cat $OUTPUT_HASH)" ]]; then
 fi
 rm $INPUT_HASH $OUTPUT_HASH
 echo "Verification Succeeded"
+
+sudo e2label update.img red
+echo "Image Relabeled to \"red\""


### PR DESCRIPTION
alright, this is a weird pr. There's a few things going on here:
1. There is a race condition with exporting the sound interface if it has recently been unexported. we fix this by waiting on the period file to exist before continuing.
2. If an update fails partway, we cannot safely address it using `/dev/disk/by-label`. We address this by hardcoding a relationship between labels and their logicalnames. This may require a more elegant solution when porting to other hardware platforms.
3. If an update fails partway, the downloaded, but corrupt filesystem still holds its label. We fix this by using a label for updates that is neither `green` nor `blue`.
4. There is a lock escalation error with the unstable flag. We fix this by locking server-info at the beginning of the update flow.