### PR TITLE
persist all logs

### DIFF
--- a/build/journald.conf
+++ b/build/journald.conf
@@ -1,0 +1,44 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See journald.conf(5) for details.
+
+[Journal]
+Storage=persistent
+Compress=yes
+#Seal=yes
+#SplitMode=uid
+#SyncIntervalSec=5m
+#RateLimitIntervalSec=30s
+#RateLimitBurst=10000
+SystemMaxUse=1G
+#SystemKeepFree=
+#SystemMaxFileSize=
+#SystemMaxFiles=100
+#RuntimeMaxUse=
+#RuntimeKeepFree=
+#RuntimeMaxFileSize=
+#RuntimeMaxFiles=100
+#MaxRetentionSec=
+#MaxFileSec=1month
+ForwardToSyslog=no
+#ForwardToKMsg=no
+#ForwardToConsole=no
+#ForwardToWall=yes
+#TTYPath=/dev/console
+#MaxLevelStore=debug
+#MaxLevelSyslog=debug
+#MaxLevelKMsg=notice
+#MaxLevelConsole=info
+#MaxLevelWall=emerg
+#LineMax=48K
+#ReadKMsg=yes
+#Audit=no

--- a/build/write-image.sh
+++ b/build/write-image.sh
@@ -48,6 +48,7 @@ sudo mount ${OUTPUT_DEVICE}p3 /tmp/eos-mnt
 sudo mkdir  /tmp/eos-mnt/media/boot-rw
 sudo mkdir  /tmp/eos-mnt/embassy-os
 sudo cp build/fstab /tmp/eos-mnt/etc/fstab
+sudo cp build/journald.conf /tmp/eos-mnt/etc/systemd/journald.conf
 # Enter the backend directory, copy over the built EmbassyOS binaries and systemd services, edit the nginx config, then create the .ssh directory
 cd backend/
 


### PR DESCRIPTION
NO TICKET

this mounts all logs to the data drive instead of just the journal
this also reduces the maximum disk usage of journald
the purpose of this is to help reduce load on the overlay filesystem