### PR TITLE
perform docker state build if folder doesn't exist

### DIFF
--- a/build/write-image.sh
+++ b/build/write-image.sh
@@ -39,7 +39,6 @@ sudo mv /tmp/eos-mnt/config.txt.tmp /tmp/eos-mnt/config.txt
 # Unmount the boot partition and mount embassy partition
 sudo umount /tmp/eos-mnt
 sudo mount ${OUTPUT_DEVICE}p2 /tmp/eos-mnt
-sudo touch /tmp/eos-mnt/system-rebuild # rebuild docker state on first startup
 if [ "$NO_KEY" != "1" ]; then sudo cp product_key.txt /tmp/eos-mnt; else echo "This image is being written with no product key"; fi
 sudo umount /tmp/eos-mnt
 


### PR DESCRIPTION
NO TICKET

if the docker state does not exist, we need to build it. we hacked around this by adding the `system-rebuild` file to fresh builds, but this doesn't help if you set up a fresh drive with a previously used card.