### PR TITLE
Make machine-ids and ssh host keys unique

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -58,6 +58,8 @@ ControlPort 9051
 CookieAuthentication 1
 EOF
 
+cat /embassy-os/product_key.txt | tr -d '\n' | sha256sum | head -c 32 | sed 's/$/\n/' > /etc/machine-id
+
 raspi-config nonint enable_overlayfs
 systemctl disable initialization.service
 sudo systemctl restart NetworkManager


### PR DESCRIPTION
This PR is in response to #1164 but unintuitively.

The actual problem originally arose from having different machine ids every boot. This was due to running cloud init every boot back in the couple of weeks where we were on 21.10.

RaspiOS implicitly fixed that by doing away with cloud-init. However, the reason we had cloud-init in the first place is to make ssh host keys different per machine.

This PR ultimately ensures that every Embassy has a unique machine-id and set of ssh keys, and that those materials are preserved across OTA updates.