### PR TITLE
backend: fix for loop iteration in ssl_port_status function

### DIFF
--- a/backend/src/install/mod.rs
+++ b/backend/src/install/mod.rs
@@ -1389,13 +1389,15 @@ pub fn load_images<'a, P: AsRef<Path> + 'a + Send + Sync>(
 
 fn ssl_port_status(manifests: Vec<Manifest>) -> BTreeMap<Port, (bool, PackageId)> {
     let mut ret = BTreeMap::new();
+
     for m in manifests {
-        for (id, iface) in m.interfaces.0 {
-            match iface.lan_config {
+        for (id, iface) in &m.interfaces.0 {
+            match &iface.lan_config {
                 None => {}
                 Some(cfg) => {
-                    for (p, lan) in cfg {
-                        ret.insert(p, (lan.ssl, m.id))
+                    for (&p, lan) in cfg {
+                        let m = m.clone();
+                        ret.insert(p, (lan.ssl, m.id));
                     }
                 }
             }


### PR DESCRIPTION
Not sure if this is the best/correct way to fix the issue I was experiencing. Essentially the nested for loops had trouble iterating over the manifest variable. The below code changes did fix my build.