### PR TITLE
fix overlay disabling when looking at disk drives

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -69,6 +69,11 @@ cat /embassy-os/product_key.txt | tr -d '\n' | sha256sum | head -c 32 | sed 's/$
 passwd -l pi
 
 raspi-config nonint enable_overlayfs
+
+# create a copy of the cmdline *without* the quirk string, so that it can be easily amended
+sudo cp /boot/cmdline.txt /boot/cmdline.txt.orig
+sudo sed -i 's/^/usb-storage.quirks=152d:0562:u /g' /boot/cmdline.txt
+
 systemctl disable initialization.service
 sudo systemctl restart NetworkManager
 

--- a/build/write-image.sh
+++ b/build/write-image.sh
@@ -37,9 +37,6 @@ fi
 
 sudo sed -i 's/PARTUUID=cb15ae4d-02/PARTUUID=cb15ae4d-03/g' /tmp/eos-mnt/cmdline.txt
 sudo sed -i 's/ init=\/usr\/lib\/raspi-config\/init_resize.sh//g' /tmp/eos-mnt/cmdline.txt
-# create a copy of the cmdline *without* the quirk string, so that it can be easily amended
-sudo cp /tmp/eos-mnt/cmdline.txt /tmp/eos-mnt/cmdline.txt.orig
-sudo sed -i 's/^/usb-storage.quirks=152d:0562:u /g' /tmp/eos-mnt/cmdline.txt
 
 cat /tmp/eos-mnt/config.txt | grep -v "dtoverlay=" | sudo tee /tmp/eos-mnt/config.txt.tmp
 echo "dtoverlay=pwm-2chan,disable-bt" | sudo tee -a /tmp/eos-mnt/config.txt.tmp


### PR DESCRIPTION
this is one of the weirder things I've had to debug. Thanks to @k0gen for calling attention to it.

Before this, calling `disk.list` would disable the overlay on next reboot. wild.