### PR TITLE
fix bug that prevents rpc context from dropping without server shutdown

### DIFF
--- a/backend/src/setup.rs
+++ b/backend/src/setup.rs
@@ -338,6 +338,8 @@ pub async fn execute_inner(
                 tracing::error!("Error recovering drive!: {}", e);
                 tracing::debug!("{:?}", e);
                 *ctx.recovery_status.write().await = Some(Err(e.into()));
+            } else {
+                tracing::info!("Recovery Complete!");
             }
         });
         (tor_addr, root_ca)


### PR DESCRIPTION
this was preventing full embassy restores from completing