### PR TITLE
Don't suggest fully qualified path name

### DIFF
--- a/frontend/projects/setup-wizard/src/app/modals/cifs-modal/cifs-modal.page.html
+++ b/frontend/projects/setup-wizard/src/app/modals/cifs-modal/cifs-modal.page.html
@@ -1,8 +1,6 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>
-      Connect Shared Folder
-    </ion-title>
+    <ion-title> Connect Shared Folder </ion-title>
   </ion-toolbar>
 </ion-header>
 
@@ -21,7 +19,10 @@
       ></ion-input>
     </ion-item>
     <p [hidden]="hostname.valid || hostname.pristine">
-      <ion-text color="danger">Hostname is required. e.g. 'My Computer' OR 'my-computer.local'</ion-text>
+      <ion-text color="danger"
+        >Hostname is required. e.g. 'My Computer' OR
+        'my-computer.local'</ion-text
+      >
     </p>
 
     <p>Share Name *</p>
@@ -36,7 +37,7 @@
       ></ion-input>
     </ion-item>
     <p [hidden]="path.valid || path.pristine">
-      <ion-text color="danger">Path is required</ion-text>
+      <ion-text color="danger">Share Name is required</ion-text>
     </p>
 
     <p>Username *</p>
@@ -71,12 +72,25 @@
 
 <ion-footer>
   <ion-toolbar>
-    <ion-button class="ion-padding-end" slot="end" color="dark" fill="clear" (click)="cancel()">
+    <ion-button
+      class="ion-padding-end"
+      slot="end"
+      color="dark"
+      fill="clear"
+      (click)="cancel()"
+    >
       Cancel
     </ion-button>
-    <ion-button class="ion-padding-end" slot="end" color="dark" fill="clear" strong="true" [disabled]="!cifsForm.form.valid" (click)="submit()">
+    <ion-button
+      class="ion-padding-end"
+      slot="end"
+      color="dark"
+      fill="clear"
+      strong="true"
+      [disabled]="!cifsForm.form.valid"
+      (click)="submit()"
+    >
       Verify
     </ion-button>
   </ion-toolbar>
 </ion-footer>
-

--- a/frontend/projects/setup-wizard/src/app/modals/cifs-modal/cifs-modal.page.html
+++ b/frontend/projects/setup-wizard/src/app/modals/cifs-modal/cifs-modal.page.html
@@ -28,15 +28,15 @@
     <p>Share Name *</p>
     <ion-item>
       <ion-input
-        id="path"
+        id="shareName"
         required
-        [(ngModel)]="cifs.path"
-        name="path"
-        #path="ngModel"
+        [(ngModel)]="cifs['share-name']"
+        name="shareName"
+        #shareName="ngModel"
         placeholder="ex. Share'"
       ></ion-input>
     </ion-item>
-    <p [hidden]="path.valid || path.pristine">
+    <p [hidden]="shareName.valid || shareName.pristine">
       <ion-text color="danger">Share Name is required</ion-text>
     </p>
 

--- a/frontend/projects/setup-wizard/src/app/modals/cifs-modal/cifs-modal.page.html
+++ b/frontend/projects/setup-wizard/src/app/modals/cifs-modal/cifs-modal.page.html
@@ -24,7 +24,7 @@
       <ion-text color="danger">Hostname is required. e.g. 'My Computer' OR 'my-computer.local'</ion-text>
     </p>
 
-    <p>Path *</p>
+    <p>Share Name *</p>
     <ion-item>
       <ion-input
         id="path"
@@ -32,7 +32,7 @@
         [(ngModel)]="cifs.path"
         name="path"
         #path="ngModel"
-        placeholder="ex. /Desktop/my-folder'"
+        placeholder="ex. Share'"
       ></ion-input>
     </ion-item>
     <p [hidden]="path.valid || path.pristine">

--- a/frontend/projects/setup-wizard/src/app/modals/cifs-modal/cifs-modal.page.ts
+++ b/frontend/projects/setup-wizard/src/app/modals/cifs-modal/cifs-modal.page.ts
@@ -1,6 +1,14 @@
 import { Component } from '@angular/core'
-import { AlertController, LoadingController, ModalController } from '@ionic/angular'
-import { ApiService, CifsBackupTarget, EmbassyOSRecoveryInfo } from 'src/app/services/api/api.service'
+import {
+  AlertController,
+  LoadingController,
+  ModalController,
+} from '@ionic/angular'
+import {
+  ApiService,
+  CifsBackupTarget,
+  EmbassyOSRecoveryInfo,
+} from 'src/app/services/api/api.service'
 import { PasswordPage } from '../password/password.page'
 
 @Component({
@@ -12,23 +20,23 @@ export class CifsModal {
   cifs = {
     type: 'cifs' as 'cifs',
     hostname: '',
-    path: '',
+    'share-name': '',
     username: '',
     password: '',
   }
 
-  constructor (
+  constructor(
     private readonly modalController: ModalController,
     private readonly apiService: ApiService,
     private readonly loadingCtrl: LoadingController,
     private readonly alertCtrl: AlertController,
-  ) { }
+  ) {}
 
-  cancel () {
+  cancel() {
     this.modalController.dismiss()
   }
 
-  async submit (): Promise<void> {
+  async submit(): Promise<void> {
     const loader = await this.loadingCtrl.create({
       spinner: 'lines',
       message: 'Connecting to shared folder...',
@@ -41,9 +49,12 @@ export class CifsModal {
       const is02x = embassyOS.version.startsWith('0.2')
 
       if (is02x) {
-        this.modalController.dismiss({
-          cifs: this.cifs,
-        }, 'success')
+        this.modalController.dismiss(
+          {
+            cifs: this.cifs,
+          },
+          'success',
+        )
       } else {
         this.presentModalPassword(embassyOS)
       }
@@ -54,7 +65,9 @@ export class CifsModal {
     }
   }
 
-  private async presentModalPassword (embassyOS: EmbassyOSRecoveryInfo): Promise<void> {
+  private async presentModalPassword(
+    embassyOS: EmbassyOSRecoveryInfo,
+  ): Promise<void> {
     const target: CifsBackupTarget = {
       ...this.cifs,
       mountable: true,
@@ -68,19 +81,23 @@ export class CifsModal {
     })
     modal.onDidDismiss().then(res => {
       if (res.role === 'success') {
-        this.modalController.dismiss({
-          cifs: this.cifs,
-          recoveryPassword: res.data.password,
-        }, 'success')
+        this.modalController.dismiss(
+          {
+            cifs: this.cifs,
+            recoveryPassword: res.data.password,
+          },
+          'success',
+        )
       }
     })
     await modal.present()
   }
 
-  private async presentAlertFailed (): Promise<void> {
+  private async presentAlertFailed(): Promise<void> {
     const alert = await this.alertCtrl.create({
       header: 'Connection Failed',
-      message: 'Unable to connect to shared folder. Ensure (1) target computer is connected to LAN, (2) target folder is being shared, and (3) hostname, path, and credentials are accurate.',
+      message:
+        'Unable to connect to shared folder. Ensure (1) target computer is connected to LAN, (2) target folder is being shared, and (3) hostname, path, and credentials are accurate.',
       buttons: ['OK'],
     })
     alert.present()

--- a/frontend/projects/setup-wizard/src/app/pages/recover/recover.page.ts
+++ b/frontend/projects/setup-wizard/src/app/pages/recover/recover.page.ts
@@ -1,5 +1,11 @@
 import { Component, Input } from '@angular/core'
-import { AlertController, IonicSafeString, LoadingController, ModalController, NavController } from '@ionic/angular'
+import {
+  AlertController,
+  IonicSafeString,
+  LoadingController,
+  ModalController,
+  NavController,
+} from '@ionic/angular'
 import { CifsModal } from 'src/app/modals/cifs-modal/cifs-modal.page'
 import { ApiService, DiskBackupTarget } from 'src/app/services/api/api.service'
 import { ErrorToastService } from 'src/app/services/error-toast.service'
@@ -17,7 +23,7 @@ export class RecoverPage {
   mappedDrives: MappedDisk[] = []
   hasShownGuidAlert = false
 
-  constructor (
+  constructor(
     private readonly apiService: ApiService,
     private readonly navCtrl: NavController,
     private readonly modalCtrl: ModalController,
@@ -26,45 +32,48 @@ export class RecoverPage {
     private readonly loadingCtrl: LoadingController,
     private readonly errorToastService: ErrorToastService,
     public readonly stateService: StateService,
-  ) { }
+  ) {}
 
-  async ngOnInit () {
+  async ngOnInit() {
     await this.getDrives()
   }
 
-  async refresh () {
+  async refresh() {
     this.loading = true
     await this.getDrives()
   }
 
-  driveClickable (mapped: MappedDisk) {
-    return mapped.drive['embassy-os']?.full && (this.stateService.hasProductKey || mapped.is02x)
+  driveClickable(mapped: MappedDisk) {
+    return (
+      mapped.drive['embassy-os']?.full &&
+      (this.stateService.hasProductKey || mapped.is02x)
+    )
   }
 
-  async getDrives () {
+  async getDrives() {
     this.mappedDrives = []
     try {
       const { disks, reconnect } = await this.apiService.getDrives()
-      disks.filter(d => d.partitions.length).forEach(d => {
-        d.partitions.forEach(p => {
-          const drive: DiskBackupTarget = {
-            vendor: d.vendor,
-            model: d.model,
-            logicalname: p.logicalname,
-            label: p.label,
-            capacity: p.capacity,
-            used: p.used,
-            'embassy-os': p['embassy-os'],
-          }
-          this.mappedDrives.push(
-            {
+      disks
+        .filter(d => d.partitions.length)
+        .forEach(d => {
+          d.partitions.forEach(p => {
+            const drive: DiskBackupTarget = {
+              vendor: d.vendor,
+              model: d.model,
+              logicalname: p.logicalname,
+              label: p.label,
+              capacity: p.capacity,
+              used: p.used,
+              'embassy-os': p['embassy-os'],
+            }
+            this.mappedDrives.push({
               hasValidBackup: p['embassy-os']?.full,
               is02x: drive['embassy-os']?.version.startsWith('0.2'),
               drive,
-            },
-          )
+            })
+          })
         })
-      })
 
       if (!this.mappedDrives.length && reconnect.length) {
         const list = `<ul>${reconnect.map(recon => `<li>${recon}</li>`)}</ul>`
@@ -85,7 +94,11 @@ export class RecoverPage {
       if (!!importableDrive && !this.hasShownGuidAlert) {
         const alert = await this.alertCtrl.create({
           header: 'Embassy Data Drive Detected',
-          message: new IonicSafeString(`${importableDrive.vendor || 'Unknown Vendor'} - ${importableDrive.model || 'Unknown Model' } contains Embassy data. To use this drive and its data <i>as-is</i>, click "Use Drive". This will complete the setup process.<br /><br /><b>Important</b>. If you are trying to restore from backup or update from 0.2.x, DO NOT click "Use Drive". Instead, click "Cancel" and follow instructions.`),
+          message: new IonicSafeString(
+            `${importableDrive.vendor || 'Unknown Vendor'} - ${
+              importableDrive.model || 'Unknown Model'
+            } contains Embassy data. To use this drive and its data <i>as-is</i>, click "Use Drive". This will complete the setup process.<br /><br /><b>Important</b>. If you are trying to restore from backup or update from 0.2.x, DO NOT click "Use Drive". Instead, click "Cancel" and follow instructions.`,
+          ),
           buttons: [
             {
               role: 'cancel',
@@ -109,17 +122,22 @@ export class RecoverPage {
     }
   }
 
-  async presentModalCifs (): Promise<void> {
+  async presentModalCifs(): Promise<void> {
     const modal = await this.modalCtrl.create({
       component: CifsModal,
     })
     modal.onDidDismiss().then(res => {
       if (res.role === 'success') {
-        const { hostname, path, username, password } = res.data.cifs
+        const {
+          hostname,
+          'share-name': shareName,
+          username,
+          password,
+        } = res.data.cifs
         this.stateService.recoverySource = {
           type: 'cifs',
           hostname,
-          path,
+          'share-name': shareName,
           username,
           password,
         }
@@ -130,7 +148,7 @@ export class RecoverPage {
     await modal.present()
   }
 
-  async select (target: DiskBackupTarget) {
+  async select(target: DiskBackupTarget) {
     const is02x = target['embassy-os'].version.startsWith('0.2')
 
     if (this.stateService.hasProductKey) {
@@ -154,7 +172,8 @@ export class RecoverPage {
       if (!is02x) {
         const alert = await this.alertCtrl.create({
           header: 'Error',
-          message: 'In order to use this image, you must select a drive containing a valid 0.2.x Embassy.',
+          message:
+            'In order to use this image, you must select a drive containing a valid 0.2.x Embassy.',
           buttons: [
             {
               role: 'cancel',
@@ -179,7 +198,7 @@ export class RecoverPage {
     }
   }
 
-  private async importDrive (guid: string) {
+  private async importDrive(guid: string) {
     const loader = await this.loadingCtrl.create({
       message: 'Importing Drive',
     })
@@ -194,7 +213,7 @@ export class RecoverPage {
     }
   }
 
-  private async selectRecoverySource (logicalname: string, password?: string) {
+  private async selectRecoverySource(logicalname: string, password?: string) {
     this.stateService.recoverySource = {
       type: 'disk',
       logicalname,
@@ -203,7 +222,6 @@ export class RecoverPage {
     this.navCtrl.navigateForward(`/embassy`)
   }
 }
-
 
 @Component({
   selector: 'drive-status',
@@ -214,7 +232,6 @@ export class DriveStatusComponent {
   @Input() hasValidBackup: boolean
   @Input() is02x: boolean
 }
-
 
 interface MappedDisk {
   is02x: boolean

--- a/frontend/projects/setup-wizard/src/app/services/api/api.service.ts
+++ b/frontend/projects/setup-wizard/src/app/services/api/api.service.ts
@@ -1,16 +1,16 @@
 export abstract class ApiService {
   // unencrypted
-  abstract getStatus (): Promise<GetStatusRes> // setup.status
-  abstract getDrives (): Promise<DiskListResponse> // setup.disk.list
-  abstract set02XDrive (logicalname: string): Promise<void> // setup.recovery.v2.set
-  abstract getRecoveryStatus (): Promise<RecoveryStatusRes> // setup.recovery.status
+  abstract getStatus(): Promise<GetStatusRes> // setup.status
+  abstract getDrives(): Promise<DiskListResponse> // setup.disk.list
+  abstract set02XDrive(logicalname: string): Promise<void> // setup.recovery.v2.set
+  abstract getRecoveryStatus(): Promise<RecoveryStatusRes> // setup.recovery.status
 
   // encrypted
-  abstract verifyCifs (cifs: CifsRecoverySource): Promise<EmbassyOSRecoveryInfo> // setup.cifs.verify
-  abstract verifyProductKey (): Promise<void> // echo - throws error if invalid
-  abstract importDrive (guid: string): Promise<SetupEmbassyRes> // setup.execute
-  abstract setupEmbassy (setupInfo: SetupEmbassyReq): Promise<SetupEmbassyRes> // setup.execute
-  abstract setupComplete (): Promise<void> // setup.complete
+  abstract verifyCifs(cifs: CifsRecoverySource): Promise<EmbassyOSRecoveryInfo> // setup.cifs.verify
+  abstract verifyProductKey(): Promise<void> // echo - throws error if invalid
+  abstract importDrive(guid: string): Promise<SetupEmbassyRes> // setup.execute
+  abstract setupEmbassy(setupInfo: SetupEmbassyReq): Promise<SetupEmbassyRes> // setup.execute
+  abstract setupComplete(): Promise<void> // setup.complete
 }
 
 export interface GetStatusRes {
@@ -55,7 +55,7 @@ export interface DiskBackupTarget {
 
 export interface CifsBackupTarget {
   hostname: string
-  path: string
+  'share-name': string
   username: string
   mountable: boolean
   'embassy-os': EmbassyOSRecoveryInfo | null
@@ -69,18 +69,18 @@ export interface DiskRecoverySource {
 export interface CifsRecoverySource {
   type: 'cifs'
   hostname: string
-  path: string
+  'share-name': string
   username: string
   password: string | null
 }
 
 export interface DiskInfo {
-  logicalname: string,
-  vendor: string | null,
-  model: string | null,
-  partitions: PartitionInfo[],
-  capacity: number,
-  guid: string | null, // cant back up if guid exists
+  logicalname: string
+  vendor: string | null
+  model: string | null
+  partitions: PartitionInfo[]
+  capacity: number
+  guid: string | null // cant back up if guid exists
 }
 
 export interface RecoveryStatusRes {
@@ -90,9 +90,9 @@ export interface RecoveryStatusRes {
 }
 
 export interface PartitionInfo {
-  logicalname: string,
-  label: string | null,
-  capacity: number,
-  used: number | null,
-  'embassy-os': EmbassyOSRecoveryInfo | null,
+  logicalname: string
+  label: string | null
+  capacity: number
+  used: number | null
+  'embassy-os': EmbassyOSRecoveryInfo | null
 }

--- a/frontend/projects/setup-wizard/src/app/services/api/live-api.service.ts
+++ b/frontend/projects/setup-wizard/src/app/services/api/live-api.service.ts
@@ -1,64 +1,85 @@
 import { Injectable } from '@angular/core'
-import { ApiService, CifsRecoverySource, DiskInfo, DiskListResponse, DiskRecoverySource, EmbassyOSRecoveryInfo, GetStatusRes, RecoveryStatusRes, SetupEmbassyReq, SetupEmbassyRes } from './api.service'
+import {
+  ApiService,
+  CifsRecoverySource,
+  DiskListResponse,
+  DiskRecoverySource,
+  EmbassyOSRecoveryInfo,
+  GetStatusRes,
+  RecoveryStatusRes,
+  SetupEmbassyReq,
+  SetupEmbassyRes,
+} from './api.service'
 import { HttpService } from './http.service'
 
 @Injectable({
   providedIn: 'root',
 })
 export class LiveApiService extends ApiService {
-
-  constructor (
-    private readonly http: HttpService,
-  ) { super() }
+  constructor(private readonly http: HttpService) {
+    super()
+  }
 
   // ** UNENCRYPTED **
 
-  async getStatus () {
-    return this.http.rpcRequest<GetStatusRes>({
-      method: 'setup.status',
-      params: { },
-    }, false)
+  async getStatus() {
+    return this.http.rpcRequest<GetStatusRes>(
+      {
+        method: 'setup.status',
+        params: {},
+      },
+      false,
+    )
   }
 
-  async getDrives () {
-    return this.http.rpcRequest<DiskListResponse>({
-      method: 'setup.disk.list',
-      params: { },
-    }, false)
+  async getDrives() {
+    return this.http.rpcRequest<DiskListResponse>(
+      {
+        method: 'setup.disk.list',
+        params: {},
+      },
+      false,
+    )
   }
 
-  async set02XDrive (logicalname) {
-    return this.http.rpcRequest<void>({
-      method: 'setup.recovery.v2.set',
-      params: { logicalname },
-    }, false)
+  async set02XDrive(logicalname) {
+    return this.http.rpcRequest<void>(
+      {
+        method: 'setup.recovery.v2.set',
+        params: { logicalname },
+      },
+      false,
+    )
   }
 
-  async getRecoveryStatus () {
-    return this.http.rpcRequest<RecoveryStatusRes>({
-      method: 'setup.recovery.status',
-      params: { },
-    }, false)
+  async getRecoveryStatus() {
+    return this.http.rpcRequest<RecoveryStatusRes>(
+      {
+        method: 'setup.recovery.status',
+        params: {},
+      },
+      false,
+    )
   }
 
   // ** ENCRYPTED **
 
-  async verifyCifs (source: CifsRecoverySource) {
-    source.path = source.path.replace('/\\/g', '/')
+  async verifyCifs(source: CifsRecoverySource) {
+    source['share-name'] = source['share-name'].replace('/\\/g', '/')
     return this.http.rpcRequest<EmbassyOSRecoveryInfo>({
       method: 'setup.cifs.verify',
       params: source as any,
     })
   }
 
-  async verifyProductKey () {
+  async verifyProductKey() {
     return this.http.rpcRequest<void>({
       method: 'echo',
-      params: { 'message': 'hello' },
+      params: { message: 'hello' },
     })
   }
 
-  async importDrive (guid: string) {
+  async importDrive(guid: string) {
     const res = await this.http.rpcRequest<SetupEmbassyRes>({
       method: 'setup.attach',
       params: { guid },
@@ -70,9 +91,11 @@ export class LiveApiService extends ApiService {
     }
   }
 
-  async setupEmbassy (setupInfo: SetupEmbassyReq) {
+  async setupEmbassy(setupInfo: SetupEmbassyReq) {
     if (isCifsSource(setupInfo['recovery-source'])) {
-      setupInfo['recovery-source'].path = setupInfo['recovery-source'].path.replace('/\\/g', '/')
+      setupInfo['recovery-source']['share-name'] = setupInfo['recovery-source'][
+        'share-name'
+      ].replace('/\\/g', '/')
     }
 
     const res = await this.http.rpcRequest<SetupEmbassyRes>({
@@ -86,14 +109,16 @@ export class LiveApiService extends ApiService {
     }
   }
 
-  async setupComplete () {
+  async setupComplete() {
     await this.http.rpcRequest<SetupEmbassyRes>({
       method: 'setup.complete',
-      params: { },
+      params: {},
     })
   }
 }
 
-function isCifsSource (source: CifsRecoverySource | DiskRecoverySource | undefined): source is CifsRecoverySource {
+function isCifsSource(
+  source: CifsRecoverySource | DiskRecoverySource | undefined,
+): source is CifsRecoverySource {
   return !!(source as CifsRecoverySource)?.hostname
 }

--- a/frontend/projects/ui/src/app/components/backup-drives/backup-drives.component.ts
+++ b/frontend/projects/ui/src/app/components/backup-drives/backup-drives.component.ts
@@ -278,10 +278,10 @@ const CifsSpec: ConfigSpec = {
   },
   path: {
     type: 'string',
-    name: 'Path',
+    name: 'Share Name',
     description:
-      'The directory path to the shared folder on your target device.',
-    placeholder: 'e.g. /Desktop/my-folder',
+      'The name of the Share on your target device, on Windows this is the full path to the shared folder or the name of the share on Mac and Linux',
+    placeholder: 'e.g. Share',
     nullable: false,
     masked: false,
     copyable: false,


### PR DESCRIPTION
CIFS shares are not added by specifying the path on the host machine.

Instead they are specified by giving the "share name" which on Windows and Mac are likely just the end folders. On Linux this is specified in the samba config.

THIS CHANGE IS INCOMPLETE. The code internally still says path everywhere, which will confuse developers who touch this feature next. PLEASE CHANGE THIS. I have refrained from doing so in this commit because I am not the maintainer of this code and am not entirely sure what the scope of changes I need to make is. I also don't have a quick way to test it so I don't want to make speculative changes since I could break something.