### PR TITLE
Show pkg title in notes if manifest exists

### DIFF
--- a/frontend/projects/ui/src/app/pages/notifications/notifications.page.html
+++ b/frontend/projects/ui/src/app/pages/notifications/notifications.page.html
@@ -76,7 +76,9 @@
             <h2>
               <b>
                 <span *ngIf="not['package-id']"
-                  >{{ not['package-id'] }} -
+                  >{{ patch.data['package-data'][not['package-id']] ?
+                  patch.data['package-data'][not['package-id']].manifest.title :
+                  not['package-id'] }} -
                 </span>
                 <ion-text [color]="getColor(not)"> {{ not.title }} </ion-text>
               </b>

--- a/frontend/projects/ui/src/app/pages/notifications/notifications.page.ts
+++ b/frontend/projects/ui/src/app/pages/notifications/notifications.page.ts
@@ -13,6 +13,7 @@ import {
 import { ActivatedRoute } from '@angular/router'
 import { ErrorToastService } from 'src/app/services/error-toast.service'
 import { BackupReportPage } from 'src/app/modals/backup-report/backup-report.page'
+import { PatchDbService } from 'src/app/services/patch-db/patch-db.service'
 
 @Component({
   selector: 'notifications',
@@ -34,6 +35,7 @@ export class NotificationsPage {
     private readonly modalCtrl: ModalController,
     private readonly errToast: ErrorToastService,
     private readonly route: ActivatedRoute,
+    public readonly patch: PatchDbService,
   ) {}
 
   async ngOnInit() {


### PR DESCRIPTION
NO TICKET
if the pkg exists in package-data, use the title on the manifest when displaying notes, otherwise show the pkg id