### PR TITLE
speed up shutdown

### DIFF
--- a/backend/src/sound.rs
+++ b/backend/src/sound.rs
@@ -347,7 +347,7 @@ pub const CHIME: Song<[(Option<Note>, TimeSlice); 2]> = song!(400, [
     note(E, 6, Tie(&Dot(&Quarter), &Half));
 ]);
 
-pub const SHUTDOWN: Song<[(Option<Note>, TimeSlice); 12]> = song!(120, [
+pub const SHUTDOWN: Song<[(Option<Note>, TimeSlice); 12]> = song!(200, [
     note(C, 5, Eighth);
     rest(Eighth);
     note(G, 4, Triplet(&Eighth));


### PR DESCRIPTION
Speed up shutdown sound from 120 to 200 qpm to make it sound more crisp