### PR TITLE
Bugfix/fix syntax change user

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -4,7 +4,7 @@
 set -e
 
 # introduce start9 username and embassy as default password
-if ! [ $(users) = "start9" ]
+if ! [ "$(users)" = "start9" ]
 then
 	usermod -l start9 -d /home/start9 -m pi
 	groupmod --new-name start9 pi

--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -4,7 +4,7 @@
 set -e
 
 # introduce start9 username and embassy as default password
-if ! [ "$(users)" = "start9" ]
+if ! awk -F: '{ print $1}' /etc/passwd | grep start9
 then
 	usermod -l start9 -d /home/start9 -m pi
 	groupmod --new-name start9 pi


### PR DESCRIPTION
turns out that `users` shows logged in users, not the users on the system. So it requires you to ssh in in order to actually get it unjammed. This fixes that.