### PR TITLE
start with clean tor state

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -81,6 +81,9 @@ else
 	head -c 16 /dev/urandom | xxd -p | sed 's/$/\n/' > /etc/machine-id
 fi
 
+systemctl stop tor
+rm -rf /var/lib/tor/*
+
 raspi-config nonint enable_overlayfs
 
 # create a copy of the cmdline *without* the quirk string, so that it can be easily amended


### PR DESCRIPTION
this prevents us from shipping everyone the same tor state, and means restarts will result in a tor state rebuild, which can help resolve connectivity issues