### PR TITLE
fix init

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -16,6 +16,9 @@ passwd -l start9
 ! test -f /etc/docker/daemon.json || rm /etc/docker/daemon.json
 mount -o remount,rw /boot
 
+apt-mark hold raspberrypi-bootloader
+apt-mark hold raspberrypi-kernel
+
 apt-get update
 apt-get install -y \
 	tor \


### PR DESCRIPTION
this unfortunately locks the kernel version to 5.10.92, which is affected by [this](https://orca.security/resources/blog/linux-privilege-escalation-vulnerability-dirty-pipe-cve-2022-0847/) 
updating the kernel should be prioritized for the next patch version