### PR TITLE
wait for time sync up to 60s

### DIFF
--- a/backend/embassy-init.service
+++ b/backend/embassy-init.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Embassy Init
-After=network.target ntp.service
+After=network.target
 Requires=network.target
-Wants=avahi-daemon.service nginx.service tor.service ntp.service
+Wants=avahi-daemon.service nginx.service tor.service
 
 [Service]
 Type=oneshot

--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -37,7 +37,6 @@ apt-get install -y \
 	ecryptfs-utils \
 	cifs-utils \
 	samba-common-bin \
-	ntp \
 	network-manager \
 	vim \
 	jq \
@@ -90,9 +89,9 @@ rm -rf /var/lib/tor/*
 raspi-config nonint enable_overlayfs
 
 # create a copy of the cmdline *without* the quirk string, so that it can be easily amended
-sudo sed -i 's/usb-storage.quirks=152d:0562:u,14cd:121c:u,0781:cfcb:u //g' /boot/cmdline.txt
-sudo cp /boot/cmdline.txt /boot/cmdline.txt.orig
-sudo sed -i 's/^/usb-storage.quirks=152d:0562:u,14cd:121c:u,0781:cfcb:u /g' /boot/cmdline.txt
+sed -i 's/usb-storage.quirks=152d:0562:u,14cd:121c:u,0781:cfcb:u //g' /boot/cmdline.txt
+cp /boot/cmdline.txt /boot/cmdline.txt.orig
+sed -i 's/^/usb-storage.quirks=152d:0562:u,14cd:121c:u,0781:cfcb:u /g' /boot/cmdline.txt
 
 systemctl disable initialization.service
 sudo systemctl restart NetworkManager


### PR DESCRIPTION
this fixes our time sync, and uses systemd-timesyncd.service instead of ntp