### PR TITLE
fix: Be able to port forward and see frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,9 +15,9 @@
     "build:setup-wizard": "ng run setup-wizard:build",
     "build:ui": "ng run ui:build && tsc projects/ui/postprocess.ts && node projects/ui/postprocess.js && git log | head -n1 > dist/ui/git-hash.txt",
     "build:all": "npm run build:deps && npm run build:diagnostic-ui && npm run build:setup-wizard && npm run build:ui",
-    "start:diagnostic-ui": "npm run-script build-config && ionic serve --project diagnostic-ui",
-    "start:setup-wizard": "npm run-script build-config && ionic serve --project setup-wizard",
-    "start:ui": "npm run-script build-config && ionic serve --project ui",
+    "start:diagnostic-ui": "npm run-script build-config && ionic serve --project diagnostic-ui --address 0.0.0.0",
+    "start:setup-wizard": "npm run-script build-config && ionic serve --project setup-wizard --address 0.0.0.0",
+    "start:ui": "npm run-script build-config && ionic serve --project ui --ip --address 0.0.0.0",
     "build-config": "node build-config.js"
   },
   "dependencies": {


### PR DESCRIPTION
Need this so I as a Dev can touch my Dev box (that I ssh into) and port-forward to my thin client and see the web page hosted there.