### PR TITLE
Add nginx config for proxy redirect

### DIFF
--- a/backend/src/net/nginx.conf.template
+++ b/backend/src/net/nginx.conf.template
@@ -14,6 +14,6 @@ server {{
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        proxy_redirect http://$host/ https://$host/;
+        proxy_redirect http://$host/ $scheme://$host/;
     }}
 }}

--- a/backend/src/net/nginx.conf.template
+++ b/backend/src/net/nginx.conf.template
@@ -14,5 +14,6 @@ server {{
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
+        proxy_redirect http://$host/ https://$host/;
     }}
 }}

--- a/backend/src/net/nginx.conf.template
+++ b/backend/src/net/nginx.conf.template
@@ -14,6 +14,6 @@ server {{
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        proxy_redirect http://$host/ $scheme://$host/;
+        {proxy_redirect_directive}
     }}
 }}

--- a/backend/src/net/nginx.rs
+++ b/backend/src/net/nginx.rs
@@ -91,7 +91,7 @@ impl NginxControllerInner {
         for (id, meta) in interface_map.iter() {
             for (port, lan_port_config) in meta.lan_config.iter() {
                 // get ssl certificate chain
-                let (listen_args, ssl_certificate_line, ssl_certificate_key_line) =
+                let (listen_args, ssl_certificate_line, ssl_certificate_key_line, proxy_redirect_directive) =
                     if lan_port_config.ssl {
                         // these have already been written by the net controller
                         let package_path = nginx_root.join(format!("ssl/{}", package));
@@ -115,9 +115,10 @@ impl NginxControllerInner {
                             format!("{} ssl", port.0),
                             format!("ssl_certificate {};", ssl_path_cert.to_str().unwrap()),
                             format!("ssl_certificate_key {};", ssl_path_key.to_str().unwrap()),
+                            format!("proxy_redirect http://$host/ https://$host/;"),
                         )
                     } else {
-                        (format!("{}", port.0), String::from(""), String::from(""))
+                        (format!("{}", port.0), String::from(""), String::from(""), String::from(""))
                     };
                 // write nginx configs
                 let nginx_conf_path = nginx_root.join(format!(
@@ -135,6 +136,7 @@ impl NginxControllerInner {
                         ssl_certificate_key_line = ssl_certificate_key_line,
                         app_ip = ipv4,
                         internal_port = lan_port_config.internal,
+                        proxy_redirect_directive = proxy_redirect_directive,
                     ),
                 )
                 .await


### PR DESCRIPTION
The problem

My app (https://github.com/squeaknode/squeaknode-wrapper) uses Flask for the UI interface. The Flask server uses redirects for the login/logout/index routes. When a redirect happens in the Squeaknode app, it tries to redirect to "http://..." because Flask does not know that it is behind a reverse proxy.

The solution

Add a config to Nginx so that all redirects go to the correct "https://..." url.

I tested this by manually editing the `/etc/nginx/sites-enabled/squeaknode_main_443.conf` file to include:

```
proxy_redirect http://$host/ https://$host/;
```

Then I did `systemctl reload nginx`.

After that, the Squeaknode login/logout works fine.