### PR TITLE
Proxy local frontend to remote backend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,4 @@ postprocess.js
 /plugins
 
 config.json
+proxy.conf.json

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,6 +25,8 @@ v8.0.0
 
 ## Running locally with mocks
 
+1. Clone the repository
+
 ```
 git clone https://github.com/Start9Labs/embassy-os.git
 cd embassy-os
@@ -34,7 +36,7 @@ npm ci
 npm run build:deps
 ```
 
-Copy `config-sample.json` and its contents to a new file `config.json`.
+2. Copy `config-sample.json` and its contents to a new file `config.json`.
 
 ```
 cp config-sample.json config.json
@@ -43,10 +45,30 @@ cp config-sample.json config.json
 By default, "useMocks" is set to `true`.
 Valid values for "maskAs" are `tor` and `lan`.
 
-**Start the development server(s)**
+3. Start the development server(s)
 
 ```
 npm run start:ui
 npm run start:setup-wizard
 npm run start:diagnostic-ui
+```
+
+## Running locally with proxied backend
+
+This section enables you to run a local frontend with a remote backend (eg. hosted on a live Embassy). It assumes you have completed Step 1 and Step 2 in the [section above](#running-locally-with-mocks)
+
+1. Set `useMocks: true` in `config.json`
+
+2. Create a proxy configuration file from the sample:
+
+```
+cp proxy.conf.json.sample proxy.conf.json
+```
+
+3. Change the target address to desired IP address in `proxy.conf.json`
+
+4. Start the development server
+
+```
+npm run start:ui:proxy
 ```

--- a/frontend/config-sample.json
+++ b/frontend/config-sample.json
@@ -14,6 +14,11 @@
     "mocks": {
       "maskAs": "tor",
       "skipStartupAlerts": true
+    },
+    "marketplace": {
+      "url": "https://beta-registry-0-3.start9labs.com/",
+      "name": "Embassy Marketplace"
     }
-  }
+  },
+  "gitHash": ""
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "start:diagnostic-ui": "npm run-script build-config && ionic serve --project diagnostic-ui --address 0.0.0.0",
     "start:setup-wizard": "npm run-script build-config && ionic serve --project setup-wizard --address 0.0.0.0",
     "start:ui": "npm run-script build-config && ionic serve --project ui --ip --address 0.0.0.0",
+    "start:ui:proxy": "npm run-script build-config && ionic serve --project ui --ip --address 0.0.0.0 -- --proxy-config proxy.conf.json",
     "build-config": "node build-config.js"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,10 +15,10 @@
     "build:setup-wizard": "ng run setup-wizard:build",
     "build:ui": "ng run ui:build && tsc projects/ui/postprocess.ts && node projects/ui/postprocess.js && git log | head -n1 > dist/ui/git-hash.txt",
     "build:all": "npm run build:deps && npm run build:diagnostic-ui && npm run build:setup-wizard && npm run build:ui",
-    "start:diagnostic-ui": "npm run-script build-config && ionic serve --project diagnostic-ui --address 0.0.0.0",
-    "start:setup-wizard": "npm run-script build-config && ionic serve --project setup-wizard --address 0.0.0.0",
-    "start:ui": "npm run-script build-config && ionic serve --project ui --ip --address 0.0.0.0",
-    "start:ui:proxy": "npm run-script build-config && ionic serve --project ui --ip --address 0.0.0.0 -- --proxy-config proxy.conf.json",
+    "start:diagnostic-ui": "npm run-script build-config && ionic serve --project diagnostic-ui --host 0.0.0.0",
+    "start:setup-wizard": "npm run-script build-config && ionic serve --project setup-wizard --host 0.0.0.0",
+    "start:ui": "npm run-script build-config && ionic serve --project ui --ip --host 0.0.0.0",
+    "start:ui:proxy": "npm run-script build-config && ionic serve --project ui --ip --host 0.0.0.0 -- --proxy-config proxy.conf.json",
     "build-config": "node build-config.js"
   },
   "dependencies": {

--- a/frontend/proxy.conf.json.sample
+++ b/frontend/proxy.conf.json.sample
@@ -1,0 +1,14 @@
+{
+    "/rpc/v1": {
+        "target": "http://localhost:8100/rpc/v1"
+    },
+    "/ws": {
+        "target": "http://localhost:8100/ws"
+    },
+    "/public/*": {
+        "target": "http://localhost:8100/public",
+        "pathRewrite": {
+            "^/public": ""
+        }
+    }
+}


### PR DESCRIPTION
Make use of angular proxy configuration to use a local/development front end to test with live data on an Embassy (remote backend).