### PR TITLE
[WIP] Progress Bar for CLI Install

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -75,6 +75,7 @@ hyper = "0.14.13"
 hyper-ws-listener = { git = "https://github.com/Start9Labs/hyper-ws-listener.git", branch = "main" }
 imbl = "1.0.1"
 indexmap = { version = "1.7.0", features = ["serde"] }
+indicatif = "0.16.2"
 isocountry = "0.3.2"
 itertools = "0.10.1"
 jsonpath_lib = "0.3.0"


### PR DESCRIPTION
Adds a single dependency. 
Creates a progress bar that listens to the patchDb progress during installation. 

Note: due to hardware constraints, I was unable to  test this but it does compile/build and flash. I have marked it Work In Progress [WIP] to denote this. 

Creating this PR, I also realized my commit formatting is incorrect. I will be sure to correct before finalizing this PR. 