### PR TITLE
Enable Control Groups for Docker containers

### DIFF
--- a/build/write-image.sh
+++ b/build/write-image.sh
@@ -37,6 +37,7 @@ fi
 
 sudo sed -i 's/PARTUUID=cb15ae4d-02/PARTUUID=cb15ae4d-03/g' /tmp/eos-mnt/cmdline.txt
 sudo sed -i 's/ init=\/usr\/lib\/raspi-config\/init_resize.sh//g' /tmp/eos-mnt/cmdline.txt
+sudo sed -i 's/quiet.*/cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory quiet/g' /tmp/eos-mnt/cmdline.txt
 
 cat /tmp/eos-mnt/config.txt | grep -v "dtoverlay=" | sudo tee /tmp/eos-mnt/config.txt.tmp
 echo "dtoverlay=pwm-2chan,disable-bt" | sudo tee -a /tmp/eos-mnt/config.txt.tmp


### PR DESCRIPTION
Enabling Control Groups give Docker containers the ability to track and expose missing memory metrics.
Here is an example of desirable output of `docker stats` command from your EmbassyOS:
<img width="997" alt="Screenshot 2022-05-28 at 18 30 27" src="https://user-images.githubusercontent.com/3606313/170835595-96e80cfc-5eaa-4961-bdda-953c5c4ee839.png">

