### PR TITLE
remove interactive TTY requirement from scripts

### DIFF
--- a/backend/build-dev.sh
+++ b/backend/build-dev.sh
@@ -8,7 +8,7 @@ if [ "$0" != "./build-dev.sh" ]; then
 	exit 1
 fi
 
-alias 'rust-arm64-builder'='docker run --rm -it -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-arm-cross:aarch64'
+alias 'rust-arm64-builder'='docker run --rm -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-arm-cross:aarch64'
 
 cd ..
 rust-arm64-builder sh -c "(cd backend && cargo build)"

--- a/backend/build-portable-dev.sh
+++ b/backend/build-portable-dev.sh
@@ -8,7 +8,7 @@ if [ "$0" != "./build-portable-dev.sh" ]; then
 	exit 1
 fi
 
-alias 'rust-musl-builder'='docker run --rm -it -v "$HOME"/.cargo/registry:/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-musl-cross:x86_64-musl'
+alias 'rust-musl-builder'='docker run --rm -v "$HOME"/.cargo/registry:/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-musl-cross:x86_64-musl'
 
 cd ..
 rust-musl-builder sh -c "(cd backend && cargo +beta build --target=x86_64-unknown-linux-musl --no-default-features)"

--- a/backend/build-portable.sh
+++ b/backend/build-portable.sh
@@ -8,7 +8,7 @@ if [ "$0" != "./build-portable.sh" ]; then
 	exit 1
 fi
 
-alias 'rust-musl-builder'='docker run --rm -it -v "$HOME"/.cargo/registry:/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-musl-cross:x86_64-musl'
+alias 'rust-musl-builder'='docker run --rm -v "$HOME"/.cargo/registry:/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-musl-cross:x86_64-musl'
 
 cd ..
 rust-musl-builder sh -c "(cd backend && cargo +beta build --release --target=x86_64-unknown-linux-musl --no-default-features)"

--- a/backend/build-prod.sh
+++ b/backend/build-prod.sh
@@ -8,7 +8,7 @@ if [ "$0" != "./build-prod.sh" ]; then
 	exit 1
 fi
 
-alias 'rust-arm64-builder'='docker run --rm -it -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src -P start9/rust-arm-cross:aarch64'
+alias 'rust-arm64-builder'='docker run --rm -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src -P start9/rust-arm-cross:aarch64'
 
 cd ..
 FLAGS=""

--- a/build/make-image.sh
+++ b/build/make-image.sh
@@ -30,7 +30,7 @@ fi
 export LOOPDEV=$(sudo losetup --show -fP raspios.img)
 ./build/partitioning.sh
 ./build/write-image.sh
-sudo e2fsck -f 	`partition_for ${OUTPUT_DEVICE} 3`
+sudo e2fsck -f -y `partition_for ${OUTPUT_DEVICE} 3`
 sudo resize2fs -M `partition_for ${OUTPUT_DEVICE} 3`
 BLOCK_INFO=$(sudo dumpe2fs `partition_for ${OUTPUT_DEVICE} 3`)
 BLOCK_COUNT=$(echo "$BLOCK_INFO" | grep "Block count:" | sed 's/Block count:\s\+//g')

--- a/system-images/compat/build.sh
+++ b/system-images/compat/build.sh
@@ -8,7 +8,7 @@ if [ "$0" != "./build.sh" ]; then
 	exit 1
 fi
 
-alias 'rust-musl-builder'='docker run --rm -it -v "$HOME"/.cargo/registry:/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-musl-cross:aarch64-musl'
+alias 'rust-musl-builder'='docker run --rm -v "$HOME"/.cargo/registry:/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-musl-cross:aarch64-musl'
 
 cd ../../..
 rust-musl-builder sh -c "(cd embassy-os/system-images/compat && cargo +beta build --release --target=aarch64-unknown-linux-musl --no-default-features)"


### PR DESCRIPTION
Sharing the following changes for your consideration. I needed the changes to be able to create the embassy-os image with a GitHub Actions workflow. I did not notice any regression because of this change, but please verify.

Currently some commands in the shell scripts require an interactive TTY. This PR removes that requirement from the scripts, making it possible to run the scripts in CI. This change could be considered preparation for #1032

The changes are:

1. Removed the `-it` flag from docker commands in the shell scripts. Also see [this](https://stackoverflow.com/questions/43099116/error-the-input-device-is-not-a-tty) stackoverflow post.
Fixing CI error:
`the input device is not a TTY`

2. Added a -y to the e2fsck command. This seems in line with the manual:
> -y
> Assume an answer of 'yes' to all questions; allows e2fsck to be used non-interactively. This option may not be specified at the same time as the -n or -p options.

Fixing CI error:
```
e2fsck 1.45.5 (07-Jan-2020)
e2fsck: need terminal for interactive repairs
```

Thanks for building embassy-os, looking forward to trying it out.
