### PR TITLE
add quotes to handles spaces in working dir in make-image.sh

### DIFF
--- a/build/make-image.sh
+++ b/build/make-image.sh
@@ -17,7 +17,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-cd $DIR/..
+cd "$DIR/.."
 
 truncate --size=$[(31116287+1)*512] eos.img
 if [ -z "$OUTPUT_DEVICE" ]; then


### PR DESCRIPTION
Added quotes around the path to make sure it is handled as a single argument to "cd" when $DIR contains spaces. Tested with a double quote and a spaces in my working dir.

Fixes #894