### PR TITLE
Re-mask generic input fields

### DIFF
--- a/frontend/projects/ui/src/app/components/form-object/form-object.component.html
+++ b/frontend/projects/ui/src/app/components/form-object/form-object.component.html
@@ -68,28 +68,46 @@
           <ng-template #notTextArea>
             <ion-input
               type="text"
+              *ngIf="maskDisplay[entry.key]?.masked"
               [inputmode]="spec.type === 'number' ? 'tel' : 'text'"
               [placeholder]="spec.placeholder || 'Enter ' + spec.name"
               [formControlName]="entry.key"
               (ionFocus)="presentAlertChangeWarning(entry.key, spec)"
-              (ionChange)="handleInputChange()"
+              (ionChange)="
+                handleInputChange(); transformInput($event, entry.key)
+              "
+            >
+            </ion-input>
+            <ion-input
+              *ngIf="!maskDisplay[entry.key]?.masked"
+              type="text"
+              [inputmode]="spec.type === 'number' ? 'tel' : 'text'"
+              [placeholder]="spec.placeholder || 'Enter ' + spec.name"
+              [formControlName]="entry.key"
+              (ionFocus)="presentAlertChangeWarning(entry.key, spec)"
+              (ionChange)="
+                handleInputChange(); transformInput($event, entry.key)
+              "
             >
             </ion-input>
           </ng-template>
-          <!-- removing mask button until proper solution implemented -->
-          <!-- <ion-button
+          <ion-button
             *ngIf="spec.type === 'string' && spec.masked"
             slot="end"
             fill="clear"
             color="light"
-            (click)="unmasked[entry.key] = !unmasked[entry.key]"
+            (click)="toggleMasked(entry.key)"
           >
             <ion-icon
               slot="icon-only"
-              [name]="unmasked[entry.key] ? 'eye-off-outline' : 'eye-outline'"
+              [name]="
+                !maskDisplay[entry.key]?.masked
+                  ? 'eye-off-outline'
+                  : 'eye-outline'
+              "
               size="small"
             ></ion-icon>
-          </ion-button> -->
+          </ion-button>
           <ion-note
             *ngIf="spec.type === 'number' && spec.units"
             slot="end"
@@ -177,7 +195,7 @@
             slot="end"
             name="chevron-up"
             [ngStyle]="{
-              transform: objectDisplay[entry.key].expanded
+              transform: objectDisplay[entry.key]?.expanded
                 ? 'rotate(0deg)'
                 : 'rotate(180deg)',
               transition: 'transform 0.25s ease-out'
@@ -188,7 +206,7 @@
         <div
           [id]="getElementId(entry.key)"
           [ngStyle]="{
-            'max-height': objectDisplay[entry.key].height,
+            'max-height': objectDisplay[entry.key]?.height,
             overflow: 'hidden',
             'transition-property': 'max-height',
             'transition-duration': '.25s'

--- a/frontend/projects/ui/src/app/components/form-object/form-object.component.module.ts
+++ b/frontend/projects/ui/src/app/components/form-object/form-object.component.module.ts
@@ -9,6 +9,7 @@ import { IonicModule } from '@ionic/angular'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { SharedPipesModule } from '@start9labs/shared'
 import { EnumListPageModule } from 'src/app/modals/enum-list/enum-list.module'
+import { MaskPipeModule } from 'src/app/pipes/mask/mask.module'
 
 @NgModule({
   declarations: [FormObjectComponent, FormLabelComponent, FormErrorComponent],
@@ -19,6 +20,7 @@ import { EnumListPageModule } from 'src/app/modals/enum-list/enum-list.module'
     ReactiveFormsModule,
     SharedPipesModule,
     EnumListPageModule,
+    MaskPipeModule,
   ],
   exports: [FormObjectComponent, FormLabelComponent, FormErrorComponent],
 })

--- a/frontend/projects/ui/src/app/modals/generic-input/generic-input.component.html
+++ b/frontend/projects/ui/src/app/modals/generic-input/generic-input.component.html
@@ -22,14 +22,25 @@
         <ion-item lines="none" color="dark">
           <ion-input
             #mainInput
+            *ngIf="!masked"
             type="text"
-            [(ngModel)]="value"
             name="value"
+            [ngModel]="value"
+            (ngModelChange)="transformInput($event)"
             [placeholder]="options.placeholder"
             (ionChange)="error = ''"
           ></ion-input>
-          <!-- removing mask button until proper solution implemented -->
-          <!-- <ion-button
+          <ion-input
+            #mainInput
+            *ngIf="masked"
+            type="text"
+            name="value"
+            [ngModel]="maskedValue"
+            (ngModelChange)="transformInput($event)"
+            [placeholder]="options.placeholder"
+            (ionChange)="error = ''"
+          ></ion-input>
+          <ion-button
             slot="end"
             *ngIf="options.useMask"
             fill="clear"
@@ -38,10 +49,10 @@
           >
             <ion-icon
               slot="icon-only"
-              [name]="unmasked ? 'eye-off-outline' : 'eye-outline'"
+              [name]="!masked ? 'eye-off-outline' : 'eye-outline'"
               size="small"
             ></ion-icon>
-          </ion-button> -->
+          </ion-button>
         </ion-item>
         <!-- error -->
         <p *ngIf="error">

--- a/frontend/projects/ui/src/app/modals/generic-input/generic-input.component.module.ts
+++ b/frontend/projects/ui/src/app/modals/generic-input/generic-input.component.module.ts
@@ -5,6 +5,7 @@ import { IonicModule } from '@ionic/angular'
 import { RouterModule } from '@angular/router'
 import { SharedPipesModule } from '@start9labs/shared'
 import { FormsModule } from '@angular/forms'
+import { MaskPipeModule } from 'src/app/pipes/mask/mask.module'
 
 @NgModule({
   declarations: [GenericInputComponent],
@@ -14,6 +15,7 @@ import { FormsModule } from '@angular/forms'
     FormsModule,
     RouterModule.forChild([]),
     SharedPipesModule,
+    MaskPipeModule,
   ],
   exports: [GenericInputComponent],
 })

--- a/frontend/projects/ui/src/app/modals/generic-input/generic-input.component.ts
+++ b/frontend/projects/ui/src/app/modals/generic-input/generic-input.component.ts
@@ -1,20 +1,26 @@
 import { Component, Input, ViewChild } from '@angular/core'
 import { ModalController, IonicSafeString, IonInput } from '@ionic/angular'
 import { getErrorMessage } from '@start9labs/shared'
+import { MaskPipe } from 'src/app/pipes/mask/mask.pipe'
 
 @Component({
   selector: 'generic-input',
   templateUrl: './generic-input.component.html',
   styleUrls: ['./generic-input.component.scss'],
+  providers: [MaskPipe],
 })
 export class GenericInputComponent {
   @ViewChild('mainInput') elem: IonInput
   @Input() options: GenericInputOptions
   value: string
-  unmasked = false
+  maskedValue: string
+  masked = true
   error: string | IonicSafeString
 
-  constructor(private readonly modalCtrl: ModalController) {}
+  constructor(
+    private readonly modalCtrl: ModalController,
+    private readonly mask: MaskPipe,
+  ) {}
 
   ngOnInit() {
     const defaultOptions: Partial<GenericInputOptions> = {
@@ -37,11 +43,25 @@ export class GenericInputComponent {
   }
 
   toggleMask() {
-    this.unmasked = !this.unmasked
+    this.masked = !this.masked
   }
 
   cancel() {
     this.modalCtrl.dismiss()
+  }
+
+  transformInput(newValue: string) {
+    let i = 0
+    this.value = newValue
+      .split('')
+      .map(x => {
+        if (x === '●') {
+          return this.value[i++]
+        }
+        return x
+      })
+      .join('')
+    this.maskedValue = this.mask.transform(this.value)
   }
 
   async submit() {


### PR DESCRIPTION
This PR addresses masking for input fields that use the `generic-input-component`.

