### PR TITLE
chore: Add tracing for debuging the js procedure slowness

### DIFF
--- a/backend/src/procedure/mod.rs
+++ b/backend/src/procedure/mod.rs
@@ -64,15 +64,7 @@ impl PackageProcedure {
         allow_inject: bool,
         timeout: Option<Duration>,
     ) -> Result<Result<O, (i32, String)>, Error> {
-        tracing::trace!(
-            "Procedure execute {} {} - {:?}",
-            match self {
-                PackageProcedure::Docker(_) => "docker",
-                PackageProcedure::Script(_) => "JS",
-            },
-            pkg_id,
-            name
-        );
+        tracing::trace!("Procedure execute {} {} - {:?}", self, pkg_id, name);
         match self {
             PackageProcedure::Docker(procedure) => {
                 procedure
@@ -115,15 +107,7 @@ impl PackageProcedure {
         timeout: Option<Duration>,
         name: ProcedureName,
     ) -> Result<Result<O, (i32, String)>, Error> {
-        tracing::trace!(
-            "Procedure sandboxed {} {} - {:?}",
-            match self {
-                PackageProcedure::Docker(_) => "docker",
-                PackageProcedure::Script(_) => "JS",
-            },
-            pkg_id,
-            name
-        );
+        tracing::trace!("Procedure sandboxed {} {} - {:?}", self, pkg_id, name);
         match self {
             PackageProcedure::Docker(procedure) => {
                 procedure
@@ -140,6 +124,15 @@ impl PackageProcedure {
     }
 }
 
+impl std::fmt::Display for PackageProcedure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PackageProcedure::Docker(_) => write!(f, "Docker")?,
+            PackageProcedure::Script(_) => write!(f, "JS")?,
+        }
+        Ok(())
+    }
+}
 #[derive(Debug)]
 pub struct NoOutput;
 impl<'de> Deserialize<'de> for NoOutput {

--- a/backend/src/procedure/mod.rs
+++ b/backend/src/procedure/mod.rs
@@ -64,6 +64,15 @@ impl PackageProcedure {
         allow_inject: bool,
         timeout: Option<Duration>,
     ) -> Result<Result<O, (i32, String)>, Error> {
+        tracing::trace!(
+            "Procedure execute {} {} - {:?}",
+            match self {
+                PackageProcedure::Docker(_) => "docker",
+                PackageProcedure::Script(_) => "JS",
+            },
+            pkg_id,
+            name
+        );
         match self {
             PackageProcedure::Docker(procedure) => {
                 procedure
@@ -106,6 +115,15 @@ impl PackageProcedure {
         timeout: Option<Duration>,
         name: ProcedureName,
     ) -> Result<Result<O, (i32, String)>, Error> {
+        tracing::trace!(
+            "Procedure sandboxed {} {} - {:?}",
+            match self {
+                PackageProcedure::Docker(_) => "docker",
+                PackageProcedure::Script(_) => "JS",
+            },
+            pkg_id,
+            name
+        );
         match self {
             PackageProcedure::Docker(procedure) => {
                 procedure


### PR DESCRIPTION
While debuging why configSet was slow, was using this trace. @chrisguida  thought it would be nice if others could trace this too.
