### PR TITLE
fix: Make it so we only need the password on the backup

### DIFF
--- a/backend/src/backup/restore.rs
+++ b/backend/src/backup/restore.rs
@@ -44,26 +44,22 @@ fn parse_comma_separated(arg: &str, _: &ArgMatches<'_>) -> Result<Vec<PackageId>
 }
 
 #[command(rename = "restore", display(display_none))]
-#[instrument(skip(ctx, old_password, password))]
+#[instrument(skip(ctx, password))]
 pub async fn restore_packages_rpc(
     #[context] ctx: RpcContext,
     #[arg(parse(parse_comma_separated))] ids: Vec<PackageId>,
     #[arg(rename = "target-id")] target_id: BackupTargetId,
-    #[arg(rename = "old-password", long = "old-password")] old_password: Option<String>,
     #[arg] password: String,
 ) -> Result<WithRevision<()>, Error> {
     let mut db = ctx.db.handle();
     let fs = target_id
         .load(&mut ctx.secret_store.acquire().await?)
         .await?;
-    let mut backup_guard = BackupMountGuard::mount(
+    let backup_guard = BackupMountGuard::mount(
         TmpMountGuard::mount(&fs, ReadOnly).await?,
-        old_password.as_ref().unwrap_or(&password),
+        &password,
     )
     .await?;
-    if old_password.is_some() {
-        backup_guard.change_password(&password)?;
-    }
 
     let (revision, backup_guard, tasks, _) =
         restore_packages(&ctx, &mut db, backup_guard, ids).await?;

--- a/backend/src/backup/restore.rs
+++ b/backend/src/backup/restore.rs
@@ -53,7 +53,6 @@ pub async fn restore_packages_rpc(
     #[arg] password: String,
 ) -> Result<WithRevision<()>, Error> {
     let mut db = ctx.db.handle();
-    check_password_against_db(&mut ctx.secret_store.acquire().await?, &password).await?;
     let fs = target_id
         .load(&mut ctx.secret_store.acquire().await?)
         .await?;


### PR DESCRIPTION
Fixes https://github.com/Start9Labs/embassy-os/issues/1488

### Proof of working

First, we see what it was like before hand to recreate.

https://user-images.githubusercontent.com/2364004/175098471-667254d9-e824-4e7f-b6fd-e66a1adfe645.mp4

Then after the fix we run.

https://user-images.githubusercontent.com/2364004/175098519-a7182629-8484-4520-b2f9-71f5d204a6ea.mp4

Thus we see that we have fixed the issue. 

Note: The password used was for the old backup
