### PR TITLE
Default to https:// urls for repositories, remove apt-transport-https

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -22,9 +22,11 @@ mount -o remount,rw /boot
 apt-mark hold raspberrypi-bootloader
 apt-mark hold raspberrypi-kernel
 
+# Convert all repos to use https:// before apt update
+sed -i "s/http:/https:/g" /etc/apt/sources.list /etc/apt/sources.list.d/*.list
+
 apt-get update
 apt-get install -y \
-	apt-transport-https \
 	nginx \
 	libavahi-client3 \
 	avahi-daemon \


### PR DESCRIPTION
As of apt 1.5, the package apt-transport-https is no longer required because https:// is supported out of the box.
Reference: https://packages.debian.org/bullseye/apt-transport-https "This is a dummy transitional package - https support has been moved into the apt package in 1.5. It can be safely removed."  Apt is currently at 2.2.4.

Use a sed one-liner to convert all repos in /etc/apt/sources.list and /etc/apt/sources.list.d/*.list that are http:// to https:// (https:// is available for all http:// URLs currently referenced in EmbassyOS's apt repos).