### PR TITLE
Fix/adjust pipeline

### DIFF
--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -7,8 +7,8 @@ on:
     branches:
     - master
     paths:
-    - backend
-    - libs
+    - 'backend/**'
+    - 'libs/**'
 
 jobs:
   libs:

--- a/.github/workflows/frontend-pr.yaml
+++ b/.github/workflows/frontend-pr.yaml
@@ -7,7 +7,7 @@ on:
     branches:
     - master
     paths:
-    - frontend
+    - 'frontend/**'
 
 jobs:
   frontend:

--- a/.github/workflows/frontend-pr.yaml
+++ b/.github/workflows/frontend-pr.yaml
@@ -34,8 +34,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
 
-    - name: Build frontend
-      run: make frontend
+    - name: Build frontends
+      run: make frontends
 
     - name: 'Tar files to preserve file permissions'
       run: tar -cvf frontend.tar frontend/dist frontend/config.json

--- a/libs/build-arm-v8-snapshot.sh
+++ b/libs/build-arm-v8-snapshot.sh
@@ -8,9 +8,14 @@ if [ "$0" != "./build-arm-v8-snapshot.sh" ]; then
 	exit 1
 fi
 
+USE_TTY=
+if tty -s; then
+	USE_TTY="-it"
+fi
+
 echo "Building "
 cd ..
-docker run --rm -it -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-arm-cross:aarch64 sh -c "(cd libs/ && cargo build -p snapshot-creator --release )"
+docker run --rm $USE_TTY -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src start9/rust-arm-cross:aarch64 sh -c "(cd libs/ && cargo build -p snapshot-creator --release )"
 cd -
 
 echo "Creating Arm v8 Snapshot"


### PR DESCRIPTION
Adjust the pipeline introduced in #1578 so that:
1) the correct frontend target is called. Frontend make target was recently changed from `frontend` to `frontends`.
2) an interactive TTY error is fixed. Re-used a known fix from #1508.
3) the pipeline was not triggering on PR's, corrected the path syntax.