### PR TITLE
Tor repository fix for arm64

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -49,8 +49,8 @@ apt-get install -y \
 
 # Setup repository from The Guardian Project and install latest stable Tor daemon
 touch /etc/apt/sources.list.d/tor.list
-echo "deb     [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main" >> /etc/apt/sources.list.d/tor.list
-echo "deb-src [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main" >> /etc/apt/sources.list.d/tor.list
+echo "deb     [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main" >> /etc/apt/sources.list.d/tor.list
+echo "deb-src [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main" >> /etc/apt/sources.list.d/tor.list
 wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
 apt update && apt install -y tor deb.torproject.org-keyring
 


### PR DESCRIPTION
When doing `sudo apt update` you get this:
`N: Skipping acquire of configured file 'main/binary-armhf/Packages' as repository 'https://deb.torproject.org/torproject.org bullseye InRelease' doesn't support architecture 'armhf'`