### PR TITLE
fix bug when config has more keys than the incoming spec

### DIFF
--- a/frontend/projects/ui/src/app/components/form-object/form-object.component.html
+++ b/frontend/projects/ui/src/app/components/form-object/form-object.component.html
@@ -44,7 +44,10 @@
         </ion-select>
       </ion-item>
     </ng-container>
-    <div *ngIf="objectSpec[entry.key] as spec" [class.indent]="unionSpec">
+    <div
+      *ngIf="objectSpec && objectSpec[entry.key] as spec"
+      [class.indent]="unionSpec"
+    >
       <!-- string or number -->
       <ng-container *ngIf="spec.type === 'string' || spec.type === 'number'">
         <!-- label -->

--- a/frontend/projects/ui/src/app/components/form-object/form-object.component.ts
+++ b/frontend/projects/ui/src/app/components/form-object/form-object.component.ts
@@ -35,7 +35,7 @@ interface Config {
   styleUrls: ['./form-object.component.scss'],
 })
 export class FormObjectComponent {
-  @Input() objectSpec: ConfigSpec | undefined
+  @Input() objectSpec?: ConfigSpec
   @Input() formGroup: FormGroup
   @Input() unionSpec?: ValueSpecUnion
   @Input() current?: Config
@@ -62,36 +62,31 @@ export class FormObjectComponent {
   ) {}
 
   ngOnInit() {
-    if (this.objectSpec) {
-      Object.keys(this.objectSpec).forEach(key => {
-        const spec = this.objectSpec![key]
+    Object.keys(this.objectSpec || {}).forEach(key => {
+      const spec = this.objectSpec![key]
 
-        if (
-          spec.type === 'list' &&
-          ['object', 'union'].includes(spec.subtype)
-        ) {
-          this.objectListDisplay[key] = []
-          this.formGroup.get(key)?.value.forEach((obj: any, index: number) => {
-            const displayAs = (spec.spec as ListValueSpecOf<'object'>)[
-              'display-as'
-            ]
-            this.objectListDisplay[key][index] = {
-              expanded: false,
-              height: '0px',
-              displayAs: displayAs
-                ? (Mustache as any).render(displayAs, obj)
-                : '',
-            }
-          })
-        } else if (['object', 'union'].includes(spec.type)) {
-          this.objectDisplay[key] = {
+      if (spec.type === 'list' && ['object', 'union'].includes(spec.subtype)) {
+        this.objectListDisplay[key] = []
+        this.formGroup.get(key)?.value.forEach((obj: any, index: number) => {
+          const displayAs = (spec.spec as ListValueSpecOf<'object'>)[
+            'display-as'
+          ]
+          this.objectListDisplay[key][index] = {
             expanded: false,
             height: '0px',
-            hasNewOptions: false,
+            displayAs: displayAs
+              ? (Mustache as any).render(displayAs, obj)
+              : '',
           }
+        })
+      } else if (['object', 'union'].includes(spec.type)) {
+        this.objectDisplay[key] = {
+          expanded: false,
+          height: '0px',
+          hasNewOptions: false,
         }
-      })
-    }
+      }
+    })
 
     // setTimeout hack to avoid ExpressionChangedAfterItHasBeenCheckedError
     setTimeout(() => {

--- a/frontend/projects/ui/src/app/modals/app-config/app-config.page.ts
+++ b/frontend/projects/ui/src/app/modals/app-config/app-config.page.ts
@@ -129,7 +129,7 @@ export class AppConfigPage {
   }
 
   async tryConfigure() {
-    convertValuesRecursive(this.configSpec, this.configForm)
+    convertValuesRecursive(this.configForm, this.configSpec)
 
     if (this.configForm.invalid) {
       document

--- a/frontend/projects/ui/src/app/modals/generic-form/generic-form.page.ts
+++ b/frontend/projects/ui/src/app/modals/generic-form/generic-form.page.ts
@@ -44,7 +44,7 @@ export class GenericFormPage {
   }
 
   async handleClick(handler: ActionButton['handler']): Promise<void> {
-    convertValuesRecursive(this.spec, this.formGroup)
+    convertValuesRecursive(this.formGroup, this.spec)
 
     if (this.formGroup.invalid) {
       this.formGroup.markAllAsTouched()

--- a/frontend/projects/ui/src/app/services/form.service.ts
+++ b/frontend/projects/ui/src/app/services/form.service.ts
@@ -508,51 +508,53 @@ function isUnion(spec: any): spec is ListValueSpecUnion {
 }
 
 export function convertValuesRecursive(
-  configSpec: ConfigSpec,
+  configSpec: ConfigSpec | undefined,
   group: FormGroup,
 ) {
-  Object.entries(configSpec).forEach(([key, valueSpec]) => {
-    const control = group.get(key)
+  if (configSpec) {
+    Object.entries(configSpec).forEach(([key, valueSpec]) => {
+      const control = group.get(key)
 
-    if (!control) return
+      if (!control) return
 
-    if (valueSpec.type === 'number') {
-      control.setValue(control.value ? Number(control.value) : null)
-    } else if (valueSpec.type === 'string') {
-      if (!control.value) control.setValue(null)
-    } else if (valueSpec.type === 'object') {
-      convertValuesRecursive(valueSpec.spec, group.get(key) as FormGroup)
-    } else if (valueSpec.type === 'union') {
-      const formGr = group.get(key) as FormGroup
-      const spec = valueSpec.variants[formGr.controls[valueSpec.tag.id].value]
-      convertValuesRecursive(spec, formGr)
-    } else if (valueSpec.type === 'list') {
-      const formArr = group.get(key) as FormArray
-      const { controls } = formArr
+      if (valueSpec.type === 'number') {
+        control.setValue(control.value ? Number(control.value) : null)
+      } else if (valueSpec.type === 'string') {
+        if (!control.value) control.setValue(null)
+      } else if (valueSpec.type === 'object') {
+        convertValuesRecursive(valueSpec.spec, group.get(key) as FormGroup)
+      } else if (valueSpec.type === 'union') {
+        const formGr = group.get(key) as FormGroup
+        const spec = valueSpec.variants[formGr.controls[valueSpec.tag.id].value]
+        convertValuesRecursive(spec, formGr)
+      } else if (valueSpec.type === 'list') {
+        const formArr = group.get(key) as FormArray
+        const { controls } = formArr
 
-      if (valueSpec.subtype === 'number') {
-        controls.forEach(control => {
-          control.setValue(control.value ? Number(control.value) : null)
-        })
-      } else if (valueSpec.subtype === 'string') {
-        controls.forEach(control => {
-          if (!control.value) control.setValue(null)
-        })
-      } else if (valueSpec.subtype === 'object') {
-        controls.forEach(formGroup => {
-          const objectSpec = valueSpec.spec as ListValueSpecObject
-          convertValuesRecursive(objectSpec.spec, formGroup as FormGroup)
-        })
-      } else if (valueSpec.subtype === 'union') {
-        controls.forEach(formGroup => {
-          const unionSpec = valueSpec.spec as ListValueSpecUnion
-          const spec =
-            unionSpec.variants[
-              (formGroup as FormGroup).controls[unionSpec.tag.id].value
-            ]
-          convertValuesRecursive(spec, formGroup as FormGroup)
-        })
+        if (valueSpec.subtype === 'number') {
+          controls.forEach(control => {
+            control.setValue(control.value ? Number(control.value) : null)
+          })
+        } else if (valueSpec.subtype === 'string') {
+          controls.forEach(control => {
+            if (!control.value) control.setValue(null)
+          })
+        } else if (valueSpec.subtype === 'object') {
+          controls.forEach(formGroup => {
+            const objectSpec = valueSpec.spec as ListValueSpecObject
+            convertValuesRecursive(objectSpec.spec, formGroup as FormGroup)
+          })
+        } else if (valueSpec.subtype === 'union') {
+          controls.forEach(formGroup => {
+            const unionSpec = valueSpec.spec as ListValueSpecUnion
+            const spec =
+              unionSpec.variants[
+                (formGroup as FormGroup).controls[unionSpec.tag.id].value
+              ]
+            convertValuesRecursive(spec, formGroup as FormGroup)
+          })
+        }
       }
-    }
-  })
+    })
+  }
 }

--- a/frontend/projects/ui/src/app/services/form.service.ts
+++ b/frontend/projects/ui/src/app/services/form.service.ts
@@ -508,53 +508,51 @@ function isUnion(spec: any): spec is ListValueSpecUnion {
 }
 
 export function convertValuesRecursive(
-  configSpec: ConfigSpec | undefined,
   group: FormGroup,
+  configSpec?: ConfigSpec,
 ) {
-  if (configSpec) {
-    Object.entries(configSpec).forEach(([key, valueSpec]) => {
-      const control = group.get(key)
+  Object.entries(configSpec || {}).forEach(([key, valueSpec]) => {
+    const control = group.get(key)
 
-      if (!control) return
+    if (!control) return
 
-      if (valueSpec.type === 'number') {
-        control.setValue(control.value ? Number(control.value) : null)
-      } else if (valueSpec.type === 'string') {
-        if (!control.value) control.setValue(null)
-      } else if (valueSpec.type === 'object') {
-        convertValuesRecursive(valueSpec.spec, group.get(key) as FormGroup)
-      } else if (valueSpec.type === 'union') {
-        const formGr = group.get(key) as FormGroup
-        const spec = valueSpec.variants[formGr.controls[valueSpec.tag.id].value]
-        convertValuesRecursive(spec, formGr)
-      } else if (valueSpec.type === 'list') {
-        const formArr = group.get(key) as FormArray
-        const { controls } = formArr
+    if (valueSpec.type === 'number') {
+      control.setValue(control.value ? Number(control.value) : null)
+    } else if (valueSpec.type === 'string') {
+      if (!control.value) control.setValue(null)
+    } else if (valueSpec.type === 'object') {
+      convertValuesRecursive(group.get(key) as FormGroup, valueSpec.spec)
+    } else if (valueSpec.type === 'union') {
+      const formGr = group.get(key) as FormGroup
+      const spec = valueSpec.variants[formGr.controls[valueSpec.tag.id].value]
+      convertValuesRecursive(formGr, spec)
+    } else if (valueSpec.type === 'list') {
+      const formArr = group.get(key) as FormArray
+      const { controls } = formArr
 
-        if (valueSpec.subtype === 'number') {
-          controls.forEach(control => {
-            control.setValue(control.value ? Number(control.value) : null)
-          })
-        } else if (valueSpec.subtype === 'string') {
-          controls.forEach(control => {
-            if (!control.value) control.setValue(null)
-          })
-        } else if (valueSpec.subtype === 'object') {
-          controls.forEach(formGroup => {
-            const objectSpec = valueSpec.spec as ListValueSpecObject
-            convertValuesRecursive(objectSpec.spec, formGroup as FormGroup)
-          })
-        } else if (valueSpec.subtype === 'union') {
-          controls.forEach(formGroup => {
-            const unionSpec = valueSpec.spec as ListValueSpecUnion
-            const spec =
-              unionSpec.variants[
-                (formGroup as FormGroup).controls[unionSpec.tag.id].value
-              ]
-            convertValuesRecursive(spec, formGroup as FormGroup)
-          })
-        }
+      if (valueSpec.subtype === 'number') {
+        controls.forEach(control => {
+          control.setValue(control.value ? Number(control.value) : null)
+        })
+      } else if (valueSpec.subtype === 'string') {
+        controls.forEach(control => {
+          if (!control.value) control.setValue(null)
+        })
+      } else if (valueSpec.subtype === 'object') {
+        controls.forEach(formGroup => {
+          const objectSpec = valueSpec.spec as ListValueSpecObject
+          convertValuesRecursive(formGroup as FormGroup, objectSpec.spec)
+        })
+      } else if (valueSpec.subtype === 'union') {
+        controls.forEach(formGroup => {
+          const unionSpec = valueSpec.spec as ListValueSpecUnion
+          const spec =
+            unionSpec.variants[
+              (formGroup as FormGroup).controls[unionSpec.tag.id].value
+            ]
+          convertValuesRecursive(formGroup as FormGroup, spec)
+        })
       }
-    })
-  }
+    }
+  })
 }


### PR DESCRIPTION
Caught during downgrades where config has more keys than the incoming config spec

Test case: install LND v0.14.2.2, configure with defaults, downgrade to v0.13.3.1, attempt to configure, see errors below, extra options are watchtower
<img width="1680" alt="Screen Shot 2022-07-14 at 9 11 52 PM" src="https://user-images.githubusercontent.com/12953208/179142977-3c404f7a-7242-4515-920c-b580684cd388.png">
<img width="1680" alt="Screen Shot 2022-07-14 at 9 12 03 PM" src="https://user-images.githubusercontent.com/12953208/179142990-cd91afc6-591b-4e9d-8706-9d56c785e574.png">

