### PR TITLE
Fix `to` migration version input

### DIFF
--- a/backend/src/install/mod.rs
+++ b/backend/src/install/mod.rs
@@ -1340,9 +1340,9 @@ pub async fn install_s9pk<R: AsyncRead + AsyncSeek + Unpin>(
             .migrations
             .to(
                 ctx,
-                version,
-                pkg_id,
                 &prev.manifest.version,
+                pkg_id,
+                version,
                 &prev.manifest.volumes,
             )
             .map(futures::future::Either::Left);


### PR DESCRIPTION
Presently, when running migrations using JS procedure scripts, the incoming `version` variable is the version you are currently on when upgrading (which seems correct), but is what you are downgrading to on downgrade (which seems incorrect). Confirmed by logging an error in either case to see what in the incoming version actually was.

I was under the impression that this variable was _always_ the version the package is current installed at ie. the version you are on / coming from.

So, this PR fixes the downgrade case, to allow the version that you are currently on to be passed in as the input.

This fix is needed to be able to accurately write downgrades in JS script files, because we need to know to run the downgrade based on the version you are currently on. 

Please elaborate and close this issue if my logic is wrong and this was intentional by design.

EDIT: maybe this is just a limitation of the scripts implementation, that we don't know if it's a from or to migration to set equivalent ranges for either case.