### PR TITLE
run build checks only when relevant FE changes

### DIFF
--- a/frontend/lint-staged.config.js
+++ b/frontend/lint-staged.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  '**/*.{js,ts,html,md,json}': 'prettier --write',
+  '*.ts': 'tslint --fix',
+  'projects/ui/**/*.ts': () => 'npm run check:ui',
+  'projects/shared/**/*.ts': () => 'npm run check:shared',
+  'projects/diagnostic-ui/**/*.ts': () => 'npm run check:diagnostic-ui',
+  'projects/setup-wizard/**/*.ts': () => 'npm run check:setup-wizard',
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,11 +84,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && npm run check"
+      "pre-commit": "lint-staged --concurrent false"
     }
-  },
-  "lint-staged": {
-    "**/*.{js,ts,html,md,less,json}": "prettier --write",
-    "*.ts": "tslint --fix"
   }
 }


### PR DESCRIPTION
While attempting to add individual project build checks in the previous configuration (using the `lint-staged` key in `package.json`), I encountered this error:
```
error TS5042: Option 'project' cannot be mixed with source files on a command line.
```

Since we use projects and there is a current [limitation](https://github.com/microsoft/TypeScript/issues/27379), linting and build checks thus needed to be configured how addressed in this PR. 
