### PR TITLE
feat: atomic writing

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1940,6 +1940,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.10.2",
  "swc_atoms",
  "swc_common",
  "swc_config",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebf286c900a6d5867aeff75cfee3192857bb7f24b547d4f0df2ed6baa812c90"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -1619,6 +1619,8 @@ dependencies = [
 name = "helpers"
 version = "0.1.0"
 dependencies = [
+ "color-eyre",
+ "futures",
  "models",
  "pin-project",
  "tokio",

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -833,6 +833,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "swc_atoms",
  "swc_common",
  "swc_config",
@@ -1690,6 +1691,17 @@ name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -13,6 +13,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +89,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -155,6 +185,33 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error 0.2.0",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error 0.2.0",
+]
 
 [[package]]
 name = "convert_case"
@@ -391,6 +448,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+
+[[package]]
 name = "h2"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +709,8 @@ dependencies = [
 name = "helpers"
 version = "0.1.0"
 dependencies = [
+ "color-eyre",
+ "futures",
  "models",
  "pin-project",
  "tokio",
@@ -757,6 +832,12 @@ dependencies = [
  "typenum",
  "version_check",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1024,6 +1105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,7 +1347,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-error",
+ "tracing-error 0.1.2",
 ]
 
 [[package]]
@@ -1525,6 +1630,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"
@@ -2381,7 +2492,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
 dependencies = [
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -2389,6 +2510,17 @@ name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "sharded-slab",
  "thread_local",

--- a/libs/helpers/Cargo.toml
+++ b/libs/helpers/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+color-eyre = "0.6.2"
+futures = "0.3.21"
 pin-project = "1.0.11"
 tokio = { version = "1.19.2", features = ["full"] }
 models = { path = "../models" }

--- a/libs/helpers/src/lib.rs
+++ b/libs/helpers/src/lib.rs
@@ -1,9 +1,59 @@
 use std::future::Future;
+use std::path::{Path, PathBuf};
 
+use color_eyre::eyre::{eyre, Context, Error};
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use tokio::fs::File;
 use tokio::task::{JoinError, JoinHandle};
 
 mod script_dir;
 pub use script_dir::*;
+
+pub fn to_tmp_path(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
+    let path = path.as_ref();
+    if let (Some(parent), Some(file_name)) =
+        (path.parent(), path.file_name().and_then(|f| f.to_str()))
+    {
+        Ok(parent.join(format!(".{}.tmp", file_name)))
+    } else {
+        Err(eyre!("invalid path: {}", path.display()))
+    }
+}
+
+pub async fn canonicalize(
+    path: impl AsRef<Path> + Send + Sync,
+    create_parent: bool,
+) -> Result<PathBuf, Error> {
+    fn create_canonical_folder<'a>(
+        path: impl AsRef<Path> + Send + Sync + 'a,
+    ) -> BoxFuture<'a, Result<PathBuf, Error>> {
+        async move {
+            let path = canonicalize(path, true).await?;
+            tokio::fs::create_dir(&path)
+                .await
+                .with_context(|| path.display().to_string())?;
+            Ok(path)
+        }
+        .boxed()
+    }
+    let path = path.as_ref();
+    if tokio::fs::metadata(path).await.is_err() {
+        if let (Some(parent), Some(file_name)) = (path.parent(), path.file_name()) {
+            if create_parent && tokio::fs::metadata(parent).await.is_err() {
+                return Ok(create_canonical_folder(parent).await?.join(file_name));
+            } else {
+                return Ok(tokio::fs::canonicalize(parent)
+                    .await
+                    .with_context(|| parent.display().to_string())?
+                    .join(file_name));
+            }
+        }
+    }
+    tokio::fs::canonicalize(&path)
+        .await
+        .with_context(|| path.display().to_string())
+}
 
 #[pin_project::pin_project(PinnedDrop)]
 pub struct NonDetachingJoinHandle<T>(#[pin] JoinHandle<T>);
@@ -27,5 +77,76 @@ impl<T> Future for NonDetachingJoinHandle<T> {
     ) -> std::task::Poll<Self::Output> {
         let this = self.project();
         this.0.poll(cx)
+    }
+}
+
+pub struct AtomicFile {
+    tmp_path: PathBuf,
+    path: PathBuf,
+    file: Option<File>,
+}
+impl AtomicFile {
+    pub async fn new(
+        path: impl AsRef<Path> + Send + Sync,
+        tmp_path: Option<impl AsRef<Path> + Send + Sync>,
+    ) -> Result<Self, Error> {
+        let path = canonicalize(&path, true).await?;
+        let tmp_path = if let Some(tmp_path) = tmp_path {
+            canonicalize(&tmp_path, true).await?
+        } else {
+            to_tmp_path(&path)?
+        };
+        let file = File::create(&tmp_path)
+            .await
+            .with_context(|| tmp_path.display().to_string())?;
+        Ok(Self {
+            tmp_path,
+            path,
+            file: Some(file),
+        })
+    }
+
+    pub async fn rollback(mut self) -> Result<(), Error> {
+        drop(self.file.take());
+        tokio::fs::remove_file(&self.tmp_path)
+            .await
+            .with_context(|| format!("rm {}", self.tmp_path.display()))?;
+        Ok(())
+    }
+
+    pub async fn save(mut self) -> Result<(), Error> {
+        use tokio::io::AsyncWriteExt;
+        if let Some(file) = self.file.as_mut() {
+            file.flush().await?;
+            file.shutdown().await?;
+            file.sync_all().await?;
+        }
+        drop(self.file.take());
+        tokio::fs::rename(&self.tmp_path, &self.path)
+            .await
+            .with_context(|| {
+                format!("mv {} -> {}", self.tmp_path.display(), self.path.display())
+            })?;
+        Ok(())
+    }
+}
+impl std::ops::Deref for AtomicFile {
+    type Target = File;
+    fn deref(&self) -> &Self::Target {
+        self.file.as_ref().unwrap()
+    }
+}
+impl std::ops::DerefMut for AtomicFile {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.file.as_mut().unwrap()
+    }
+}
+impl Drop for AtomicFile {
+    fn drop(&mut self) {
+        if let Some(file) = self.file.take() {
+            drop(file);
+            let path = std::mem::take(&mut self.tmp_path);
+            tokio::spawn(async move { tokio::fs::remove_file(path).await.unwrap() });
+        }
     }
 }

--- a/libs/js_engine/Cargo.toml
+++ b/libs/js_engine/Cargo.toml
@@ -33,6 +33,7 @@ swc_eq_ignore_macros = "=0.1.0"
 swc_macros_common = "=0.3.5"
 swc_visit = "=0.3.0"
 swc_visit_macros = "=0.3.1"
+sha2 = "0.10.2"
 models = { path = "../models" }
 helpers = { path = "../helpers" }
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/libs/js_engine/src/lib.rs
+++ b/libs/js_engine/src/lib.rs
@@ -530,12 +530,12 @@ mod fns {
             let last = volume_path
                 .iter()
                 .last()
-                .ok_or_else(|| anyhow!("Volume is not able to have temp dir"))?
+                .ok_or_else(|| anyhow!("Unreachable: Volume path is `/`"))?
                 .to_str()
-                .ok_or_else(|| anyhow!("Volume is not able to have temp"))?;
+                .ok_or_else(|| anyhow!("Unreachable: Volume path contains non-UTF-8 characters"))?;
             let mut tmp = volume_path
                 .parent()
-                .ok_or_else(|| anyhow!("Volume is not able to have temp"))?
+                .ok_or_else(|| anyhow!("Unreachable: Volume path is `/`"))?
                 .to_path_buf();
             tmp.push(&format!(".{}.tmp", last));
             tmp


### PR DESCRIPTION
### About

Renames are safer and are more atomic than just writing to a file. 

Why not just using a `tmp` file:
- What if the service is writing it's own `.tmp` files and the file names conflict? we could clobber them and cause weird bugs in the service
- What if the service has behaviors that depend on stat-ing a directory? The new file could cause it to try to do something invalid

### Proof it works
Nothing needs to change on the api side. Thus the old tests still working is proof that it works
![image](https://user-images.githubusercontent.com/2364004/180043921-337a13a5-e294-4d76-a54b-e26f93798f41.png)
