### PR TITLE
add x86 build and run unittests to backend pipeline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ A matrix-strategy has been used to build for both x86_64 and aarch64 platforms i
 Unittests are run using [cargo-nextest]( https://nexte.st/). First the sources are (cross-)compiled and archived. The archive is then run on the correct platform.
 Because nextest currently does not publish a pre-built aarch64 binary, there is a stage for building this.
 
-## frontend-pr
+## frontend
 Runs: manually (on: workflow_dispatch) or called by product-pipeline (on: workflow_call)
 
 This workflow builds the frontends.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,6 @@ A matrix-strategy has been used to build for both x86_64 and aarch64 platforms i
 ### Running unittests
 
 Unittests are run using [cargo-nextest]( https://nexte.st/). First the sources are (cross-)compiled and archived. The archive is then run on the correct platform.
-Because nextest currently does not publish a pre-built aarch64 binary, there is a stage for building this.
 
 ## frontend
 Runs: manually (on: workflow_dispatch) or called by product-pipeline (on: workflow_call)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,20 +1,26 @@
 # This folder contains GitHub Actions workflows for building the project
 
-## backend-pr
-Runs: when a pull request targets the master branch and changes the libs/ and/or backend/ folders
+## backend
+Runs: manually (on: workflow_dispatch) or called by product-pipeline (on: workflow_call)
 
-This workflow uses the actions docker/setup-qemu-action@v1 and docker/setup-buildx-action@v1 to prepare the environment for aarch64 cross complilation using docker buildx.
-A matrix-strategy has been used for building the v8 snapshot instead of the makefile to allow parallel job execution.
+This workflow uses the actions and docker/setup-buildx-action@v1 to prepare the environment for aarch64 cross complilation using docker buildx.
+When execution of aarch64 containers is required the action docker/setup-qemu-action@v1 is added.
+A matrix-strategy has been used to build for both x86_64 and aarch64 platforms in parallel.
+
+### Running unittests
+
+Unittests are run using [cargo-nextest]( https://nexte.st/). First the sources are (cross-)compiled and archived. The archive is then run on the correct platform.
+Because nextest currently does not publish a pre-built aarch64 binary, there is a stage for building this.
 
 ## frontend-pr
-Runs: when a pull request targets the master branch and changes the frontend/ folder
+Runs: manually (on: workflow_dispatch) or called by product-pipeline (on: workflow_call)
 
 This workflow builds the frontends.
 
 ## product
-Runs: when a change to the master branch is made
+Runs: when a pull request targets the master or next branch and when a change to the master or next branch is made
 
-This workflow builds everything, re-using the backend-pr and frontend-pr workflows.
+This workflow builds everything, re-using the backend and frontend workflows.
 The download and extraction order of artifacts is relevant to `make`, as it checks the file timestamps to decide which targets need to be executed.
 
 Result: eos.img

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -70,11 +70,8 @@ jobs:
         target: [x86_64, aarch64]
         include:
           - target: x86_64
-            build_command: cd backend && cargo build --release --target x86_64-unknown-linux-gnu
             snapshot_download: js_snapshot
-
           - target: aarch64
-            build_command: make backend
             snapshot_download: arm_js_snapshot
     runs-on: ubuntu-latest
     needs: build_libs
@@ -111,14 +108,13 @@ jobs:
 
     - name: Check Git Hash
       run: ./check-git-hash.sh
-      if: ${{ matrix.target == 'x86_64' }}
 
     - name: Check Environment
       run: ./check-environment.sh
-      if: ${{ matrix.target == 'x86_64' }}
 
     - name: Build backend
-      run: ${{ matrix.build_command }}
+      run: cargo build --release --target x86_64-unknown-linux-gnu
+      working-directory: backend
       if: ${{ matrix.target == 'x86_64' }}
 
     - name: Build backend

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -103,7 +103,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           backend/target/
-        key: ${{ runner.os }}-cargo-backend-${{ hashFiles('backend/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-backend-${{ matrix.target }}-${{ hashFiles('backend/Cargo.lock') }}
 
     - name: Install dependencies
       run: sudo apt-get install libavahi-client-dev

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -244,7 +244,7 @@ jobs:
         docker run --rm --platform linux/arm64/v8 \
         -v "/home/runner/.cargo/registry":/usr/local/cargo/registry \
         -v "$(pwd)":/home/rust/src \
-        -P rust:${{ env.RUST_VERSION }} \
+        -P ubuntu:20.04 \
         sh -c 'cd /home/rust/src &&
           mkdir -p ~/.cargo/bin &&
           tar -zxvf nextest-aarch64.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin &&

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -105,6 +105,10 @@ jobs:
           backend/target/
         key: ${{ runner.os }}-cargo-backend-${{ hashFiles('backend/Cargo.lock') }}
 
+    - name: Install dependencies
+      run: sudo apt-get install libavahi-client-dev
+      if: ${{ matrix.target == 'x86_64' }}
+      
     - name: Build backend
       run: ${{ matrix.build_command }}
       if: ${{ matrix.target == 'x86_64' }}

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -4,18 +4,22 @@ on:
   workflow_call:
   workflow_dispatch:
 
+env:
+  RUST_VERSION: "1.62.1"
+
 jobs:
-  libs:
+  build_libs:
     name: Build libs
     strategy:
+      fail-fast: false
       matrix:
-        target: [amd64, arm64]
+        target: [x86_64, aarch64]
         include:
-          - target: amd64
+          - target: x86_64
             snapshot_command: ./build-v8-snapshot.sh
             artifact_name: js_snapshot
             artifact_path: libs/js_engine/src/artifacts/JS_SNAPSHOT.bin
-          - target: arm64
+          - target: aarch64
             snapshot_command: ./build-arm-v8-snapshot.sh
             artifact_name: arm_js_snapshot
             artifact_path: libs/js_engine/src/artifacts/ARM_JS_SNAPSHOT.bin
@@ -27,9 +31,17 @@ jobs:
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
+      if: ${{ matrix.target == 'aarch64' }}
       
     - name: Set up Docker Buildx        
       uses: docker/setup-buildx-action@v1
+      if: ${{ matrix.target == 'aarch64' }}
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.RUST_VERSION }}
+        override: true
+      if: ${{ matrix.target == 'x86_64' }}
     
     - uses: actions/cache@v3
       with:
@@ -50,31 +62,44 @@ jobs:
         name: ${{ matrix.artifact_name }}
         path: ${{ matrix.artifact_path }}
 
-  backend:
+  build_backend:
     name: Build backend
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+        include:
+          - target: x86_64
+            build_command: cd backend && cargo build --release --target x86_64-unknown-linux-gnu
+            snapshot_download: js_snapshot
+
+          - target: aarch64
+            build_command: make backend
+            snapshot_download: arm_js_snapshot
     runs-on: ubuntu-latest
-    needs: libs
+    needs: build_libs
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
     
-    - name: Download arm_js_snapshot artifact
+    - name: Download ${{ matrix.snapshot_download }} artifact
       uses: actions/download-artifact@v3
       with:
-        name: arm_js_snapshot
+        name: ${{ matrix.snapshot_download }}
         path: libs/js_engine/src/artifacts/
-        
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
-      
+
     - name: Set up Docker Buildx        
       uses: docker/setup-buildx-action@v1
-
+        
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ env.RUST_VERSION }}
         override: true
+      if: ${{ matrix.target == 'x86_64' }}
     
     - uses: actions/cache@v3
       with:
@@ -87,12 +112,26 @@ jobs:
         key: ${{ runner.os }}-cargo-backend-${{ hashFiles('backend/Cargo.lock') }}
 
     - name: Build backend
-      run: make backend
+      run: ${{ matrix.build_command }}
+      if: ${{ matrix.target == 'x86_64' }}
+
+    - name: Build backend
+      run: |
+        docker run --rm \
+        -v "/home/runner/.cargo/registry":/root/.cargo/registry \
+        -v "$(pwd)":/home/rust/src \
+        -P start9/rust-arm-cross:aarch64 \
+        sh -c 'cd /home/rust/src/backend &&
+          rustup install ${{ env.RUST_VERSION }} &&
+          rustup override set ${{ env.RUST_VERSION }} &&
+          rustup target add aarch64-unknown-linux-gnu &&
+          cargo build --release --target ${{ matrix.target }}-unknown-linux-gnu'
+      if: ${{ matrix.target == 'aarch64' }}
 
     - name: 'Tar files to preserve file permissions'
-      run: tar -cvf backend.tar ENVIRONMENT.txt GIT_HASH.txt backend/target/aarch64-unknown-linux-gnu/release/embassy*
+      run: tar -cvf backend-${{ matrix.target }}.tar ENVIRONMENT.txt GIT_HASH.txt backend/target/${{ matrix.target }}-unknown-linux-gnu/release/embassy*
 
     - uses: actions/upload-artifact@v3
       with:
-        name: backend
-        path: backend.tar
+        name: backend-${{ matrix.target }}
+        path: backend-${{ matrix.target }}.tar.gz

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -109,6 +109,14 @@ jobs:
       run: sudo apt-get install libavahi-client-dev
       if: ${{ matrix.target == 'x86_64' }}
 
+    - name: Check Git Hash
+      run: ./check-git-hash.sh
+      if: ${{ matrix.target == 'x86_64' }}
+
+    - name: Check Environment
+      run: ./check-environment.sh
+      if: ${{ matrix.target == 'x86_64' }}
+
     - name: Build backend
       run: ${{ matrix.build_command }}
       if: ${{ matrix.target == 'x86_64' }}

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -108,7 +108,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install libavahi-client-dev
       if: ${{ matrix.target == 'x86_64' }}
-      
+
     - name: Build backend
       run: ${{ matrix.build_command }}
       if: ${{ matrix.target == 'x86_64' }}
@@ -133,3 +133,117 @@ jobs:
       with:
         name: backend-${{ matrix.target }}
         path: backend-${{ matrix.target }}.tar.gz
+    
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+
+    - name: Build and archive tests
+      run: cargo nextest archive --archive-file nextest-archive-${{ matrix.target }}.tar.zst --target ${{ matrix.target }}-unknown-linux-gnu
+      working-directory: backend
+      if: ${{ matrix.target == 'x86_64' }}
+
+    - name: Build and archive tests
+      run: |
+        docker run --rm \
+        -v "$HOME/.cargo/registry":/root/.cargo/registry \
+        -v "$(pwd)":/home/rust/src \
+        -P start9/rust-arm-cross:aarch64 \
+        sh -c 'cd /home/rust/src/backend &&
+          rustup install ${{ env.RUST_VERSION }} &&
+          rustup override set ${{ env.RUST_VERSION }} &&
+          rustup target add aarch64-unknown-linux-gnu &&
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin &&
+          cargo nextest archive --archive-file nextest-archive-${{ matrix.target }}.tar.zst --target ${{ matrix.target }}-unknown-linux-gnu'
+      if: ${{ matrix.target == 'aarch64' }}
+
+    - name: Upload archive to workflow
+      uses: actions/upload-artifact@v3
+      with:
+        name: nextest-archive-${{ matrix.target }}
+        path: backend/nextest-archive-${{ matrix.target }}.tar.zst
+
+  build_nextest:
+    name: Build nextest for aarch64
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build and archive tests
+      run: |
+        docker run --rm \
+        -v "$HOME/.cargo/registry":/root/.cargo/registry \
+        -v "$(pwd)":/home/rust/src \
+        -P start9/rust-arm-cross:aarch64 \
+        sh -c 'cd /home/rust/src &&
+          rustup install ${{ env.RUST_VERSION }} &&
+          rustup override set ${{ env.RUST_VERSION }} &&
+          rustup target add aarch64-unknown-linux-gnu &&
+          cargo install cargo-nextest --target aarch64-unknown-linux-gnu &&
+          cd ${CARGO_HOME:-/root/.cargo/}/bin/ &&
+          tar -cvf /home/rust/src/nextest-aarch64.tar cargo-nextest &&
+          cd /home/rust/src &&
+          gzip nextest-aarch64.tar'
+    
+    - uses: actions/upload-artifact@v3
+      with:
+        name: nextest-aarch64
+        path: nextest-aarch64.tar.gz
+  
+  run_tests_backend:
+    name: Test backend
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+        include:
+          - target: x86_64
+          - target: aarch64
+    runs-on: ubuntu-latest
+    needs: [build_backend, build_nextest]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Download nextest-aarch64 artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: nextest-aarch64
+      if: ${{ matrix.target == 'aarch64' }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      if: ${{ matrix.target == 'aarch64' }}
+
+    - name: Set up Docker Buildx        
+      uses: docker/setup-buildx-action@v1
+      if: ${{ matrix.target == 'aarch64' }}
+
+    - run: mkdir -p ~/.cargo/bin
+      if: ${{ matrix.target == 'x86_64' }}
+
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+      if: ${{ matrix.target == 'x86_64' }}
+
+    - name: Download archive
+      uses: actions/download-artifact@v3
+      with:
+        name: nextest-archive-${{ matrix.target }}
+
+    - name: Run tests
+      run: |
+        ${CARGO_HOME:-~/.cargo}/bin/cargo-nextest nextest run --no-fail-fast --archive-file nextest-archive-${{ matrix.target }}.tar.zst \
+        -E 'not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist))'
+      if: ${{ matrix.target == 'x86_64' }}
+
+    - name: Run tests
+      run: |
+        docker run --rm --platform linux/arm64/v8 \
+        -v "/home/runner/.cargo/registry":/usr/local/cargo/registry \
+        -v "$(pwd)":/home/rust/src \
+        -P rust:${{ env.RUST_VERSION }} \
+        sh -c 'cd /home/rust/src &&
+          mkdir -p ~/.cargo/bin &&
+          tar -zxvf nextest-aarch64.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin &&
+          ${CARGO_HOME:-~/.cargo}/bin/cargo-nextest nextest run --archive-file nextest-archive-${{ matrix.target }}.tar.zst \
+          -E "not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist))"'
+      if: ${{ matrix.target == 'aarch64' }}

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -88,12 +88,6 @@ jobs:
       with:
         name: ${{ matrix.snapshot_download }}
         path: libs/js_engine/src/artifacts/
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-
-    - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
         
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -166,31 +166,6 @@ jobs:
         name: nextest-archive-${{ matrix.target }}
         path: backend/nextest-archive-${{ matrix.target }}.tar.zst
 
-  build_nextest:
-    name: Build nextest for aarch64
-    runs-on: ubuntu-latest
-    steps:
-    - name: Build and archive tests
-      run: |
-        docker run --rm \
-        -v "$HOME/.cargo/registry":/root/.cargo/registry \
-        -v "$(pwd)":/home/rust/src \
-        -P start9/rust-arm-cross:aarch64 \
-        sh -c 'cd /home/rust/src &&
-          rustup install ${{ env.RUST_VERSION }} &&
-          rustup override set ${{ env.RUST_VERSION }} &&
-          rustup target add aarch64-unknown-linux-gnu &&
-          cargo install cargo-nextest --target aarch64-unknown-linux-gnu &&
-          cd ${CARGO_HOME:-/root/.cargo/}/bin/ &&
-          tar -cvf /home/rust/src/nextest-aarch64.tar cargo-nextest &&
-          cd /home/rust/src &&
-          gzip nextest-aarch64.tar'
-    
-    - uses: actions/upload-artifact@v3
-      with:
-        name: nextest-aarch64
-        path: nextest-aarch64.tar.gz
-  
   run_tests_backend:
     name: Test backend
     strategy:
@@ -201,17 +176,13 @@ jobs:
           - target: x86_64
           - target: aarch64
     runs-on: ubuntu-latest
-    needs: [build_backend, build_nextest]
+    needs: build_backend
+    env:
+      CARGO_TERM_COLOR: always
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-
-    - name: Download nextest-aarch64 artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: nextest-aarch64
-      if: ${{ matrix.target == 'aarch64' }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -233,6 +204,10 @@ jobs:
       with:
         name: nextest-archive-${{ matrix.target }}
 
+    - name: Download nextest (aarch64)
+      run: wget -O nextest-aarch64.tar.gz https://get.nexte.st/latest/linux-arm
+      if: ${{ matrix.target == 'aarch64' }}
+
     - name: Run tests
       run: |
         ${CARGO_HOME:-~/.cargo}/bin/cargo-nextest nextest run --no-fail-fast --archive-file nextest-archive-${{ matrix.target }}.tar.zst \
@@ -244,6 +219,7 @@ jobs:
         docker run --rm --platform linux/arm64/v8 \
         -v "/home/runner/.cargo/registry":/usr/local/cargo/registry \
         -v "$(pwd)":/home/rust/src \
+        -e CARGO_TERM_COLOR=${{ env.CARGO_TERM_COLOR }} \
         -P ubuntu:20.04 \
         sh -c 'cd /home/rust/src &&
           mkdir -p ~/.cargo/bin &&

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -136,7 +136,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: backend-${{ matrix.target }}
-        path: backend-${{ matrix.target }}.tar.gz
+        path: backend-${{ matrix.target }}.tar
     
     - name: Install nextest
       uses: taiki-e/install-action@nextest

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -160,6 +160,11 @@ jobs:
           cargo nextest archive --archive-file nextest-archive-${{ matrix.target }}.tar.zst --target ${{ matrix.target }}-unknown-linux-gnu'
       if: ${{ matrix.target == 'aarch64' }}
 
+    - name: Reset permissions
+      run: sudo chown -R $USER target
+      working-directory: backend
+      if: ${{ matrix.target == 'aarch64' }}
+
     - name: Upload archive to workflow
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -1,4 +1,4 @@
-name: Backend PR
+name: Backend
 
 on:
   workflow_call:

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -249,5 +249,5 @@ jobs:
           mkdir -p ~/.cargo/bin &&
           tar -zxvf nextest-aarch64.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin &&
           ${CARGO_HOME:-~/.cargo}/bin/cargo-nextest nextest run --archive-file nextest-archive-${{ matrix.target }}.tar.zst \
-          -E "not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist))"'
+          -E "not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist) | test(procedure::js_scripts::js_action_fetch) )"'
       if: ${{ matrix.target == 'aarch64' }}

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -1,4 +1,4 @@
-name: Frontend PR
+name: Frontend
 
 on:
   workflow_call:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+env:
+  NODEJS_VERSION: '16'
+
 jobs:
   frontend:
     name: Build frontend
@@ -15,7 +18,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: ${{ env.NODEJS_VERSION }}
     
     - name: Get npm cache directory
       id: npm-cache-dir

--- a/.github/workflows/product.yaml
+++ b/.github/workflows/product.yaml
@@ -20,12 +20,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-
-    - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
-
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -56,12 +50,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-        
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-
-    - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
 
     - name: Build image
       run: make system-images/utils/utils.tar

--- a/.github/workflows/product.yaml
+++ b/.github/workflows/product.yaml
@@ -66,10 +66,10 @@ jobs:
         path: system-images/utils/utils.tar
 
   backend:
-    uses: ./.github/workflows/backend-pr.yaml
+    uses: ./.github/workflows/backend.yaml
   
   frontend:
-    uses: ./.github/workflows/frontend-pr.yaml
+    uses: ./.github/workflows/frontend.yaml
     
   image:
     name: Build image

--- a/.github/workflows/product.yaml
+++ b/.github/workflows/product.yaml
@@ -20,6 +20,9 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Set up Docker Buildx        
+      uses: docker/setup-buildx-action@v1
+
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -50,6 +53,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+
+    - name: Set up Docker Buildx        
+      uses: docker/setup-buildx-action@v1
 
     - name: Build image
       run: make system-images/utils/utils.tar

--- a/.github/workflows/product.yaml
+++ b/.github/workflows/product.yaml
@@ -19,10 +19,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-        
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
-      
+
     - name: Set up Docker Buildx        
       uses: docker/setup-buildx-action@v1
 
@@ -59,7 +59,7 @@ jobs:
         
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
-      
+
     - name: Set up Docker Buildx        
       uses: docker/setup-buildx-action@v1
 
@@ -113,11 +113,11 @@ jobs:
     - name: Download backend artifact
       uses: actions/download-artifact@v3
       with:
-        name: backend
+        name: backend-aarch64
 
     - name: 'Extract backend'
       run: 
-        tar -mxvf backend.tar
+        tar -mxvf backend-aarch64.tar
 
     - name: Download frontend artifact
       uses: actions/download-artifact@v3


### PR DESCRIPTION
Here is some more pipeline work for your consideration. This adds a x86_64 build for the backend, in addition to the existing aarch64 build. Also added running the backend unittests on both platforms.

Relates to #1032 and #981

## Added backend x86_64 build

The changes made are:
* Build the backend for x86_64
* Use the target names x86_64 and aarch64 (instead of amd64 and arm64) consistently in the pipeline
* Use the same rust version everywhere
* Remove some unnecessary build steps, or add an `if` when platform specific

The current Makefile only targets aarch64, so for the build and test commands I've had to ignore the Makefile.

## Added executing unittests in pipeline

To run the unittests I found that some tests expect eOS environment features, such as existing files or directories. Perhaps they should be classified as integration tests and run in the eOS environment. I skipped those tests for now.

Running the tests on aarch64 was a little tricky. I found a couple of ways that didn't work. The obvious one was running `cargo test` in a aarch64 container. However `cargo` detects a change in filetime or signature and rebuilds everything, taking multiple hours on QEMU. I don't know how to fix that. The solution I found was to use nextest's archive option. Unfortunatly nextest doesn't release aarch64 binaries, so I added a stage to create them.
