### PR TITLE
don't use rust-arm-cross docker buildx if arch is already arm64

### DIFF
--- a/backend/build-prod.sh
+++ b/backend/build-prod.sh
@@ -21,8 +21,8 @@ if [[ "$ENVIRONMENT" =~ (^|-)dev($|-) ]]; then
 	FLAGS="dev,$FLAGS"
 fi
 
+alias 'rust-arm64-builder'='docker run $USE_TTY --rm -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src -P start9/rust-arm-cross:aarch64'
 build_cross () {
-	alias 'rust-arm64-builder'='docker run $USE_TTY --rm -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)":/home/rust/src -P start9/rust-arm-cross:aarch64'
 	cd ..
 	if [[ "$FLAGS" = "" ]]; then
 		rust-arm64-builder sh -c "(git config --global --add safe.directory '*'; cd backend && cargo build --release)"

--- a/backend/build-prod.sh
+++ b/backend/build-prod.sh
@@ -37,9 +37,12 @@ build_arm64 () {
 	if [[ "$FLAGS" = "" ]]; then
 		cargo build --release
 	else
+		echo "bins=$EMBASSY_BINS"
 		echo "FLAGS=$FLAGS"
 		cargo build --release --features $FLAGS
 	fi
+	mkdir -p target/aarch64-unknown-linux-gnu/release/
+	cp target/release/embassy* target/aarch64-unknown-linux-gnu/release/
 }
 
 if [[ "$(uname -m)" =~ ^(arm64|aarch64)$ ]]; then

--- a/build-cargo-dep.sh
+++ b/build-cargo-dep.sh
@@ -13,9 +13,17 @@ if tty -s; then
 	USE_TTY="-it"
 fi
 
-mkdir -p cargo-deps
-alias 'rust-arm64-builder'='docker run $USE_TTY --rm -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)"/cargo-deps:/home/rust/src -P start9/rust-arm-cross:aarch64'
+if [[ "$(uname -m)" =~ ^(arm64|aarch64)$ ]]; then
+	echo "Detected arm64 system, skipping cross-build"
+	cargo install "$1"
+	mkdir -p cargo-deps/aarch64-unknown-linux-gnu/release/
+	cp $(which "$1") cargo-deps/aarch64-unknown-linux-gnu/release/
+else
+	mkdir -p cargo-deps
+	echo "Detected non-arm64 system, cross-building"
+	alias 'rust-arm64-builder'='docker run $USE_TTY --rm -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)"/cargo-deps:/home/rust/src -P start9/rust-arm-cross:aarch64'
+	rust-arm64-builder cargo install "$1" --target-dir /home/rust/src
+fi
 
-rust-arm64-builder cargo install "$1" --target-dir /home/rust/src
 sudo chown -R $USER cargo-deps
 sudo chown -R $USER ~/.cargo

--- a/build-cargo-dep.sh
+++ b/build-cargo-dep.sh
@@ -13,6 +13,7 @@ if tty -s; then
 	USE_TTY="-it"
 fi
 
+alias 'rust-arm64-builder'='docker run $USE_TTY --rm -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)"/cargo-deps:/home/rust/src -P start9/rust-arm-cross:aarch64'
 if [[ "$(uname -m)" =~ ^(arm64|aarch64)$ ]]; then
 	echo "Detected arm64 system, skipping cross-build"
 	cargo install "$1"
@@ -21,7 +22,6 @@ if [[ "$(uname -m)" =~ ^(arm64|aarch64)$ ]]; then
 else
 	mkdir -p cargo-deps
 	echo "Detected non-arm64 system, cross-building"
-	alias 'rust-arm64-builder'='docker run $USE_TTY --rm -v "$HOME/.cargo/registry":/root/.cargo/registry -v "$(pwd)"/cargo-deps:/home/rust/src -P start9/rust-arm-cross:aarch64'
 	rust-arm64-builder cargo install "$1" --target-dir /home/rust/src
 fi
 


### PR DESCRIPTION
This allows fast(er) builds in a Linux VM on MacOS M1. It probably also works on a Pi, though that is untested.

Without this change, the user needs to build `rust-arm-cross` and then build the backend inside the resulting docker container using `buildx`. This process is much slower than simply building natively using `cargo build` (60 minutes -> 16 minutes on my machine).

This change also builds `cargo-deps` without `rust-arm-cross`, so `rust-arm-cross` is removed completely as a system build dependency with this feature, when run on arm64.

Unfortunately the `compat` image still requires the `rust-musl-cross` cross-build, as I couldn't figure out a straightforward way of removing that from the build process.