### PR TITLE
fix cli install

### DIFF
--- a/backend/src/install/mod.rs
+++ b/backend/src/install/mod.rs
@@ -525,7 +525,7 @@ async fn cli_install(
         let body = Body::wrap_stream(tokio_util::io::ReaderStream::new(file));
         let res = ctx
             .client
-            .post(format!("{}/rest/rpc/{}", ctx.base_url, guid,))
+            .post(format!("{}rest/rpc/{}", ctx.base_url, guid,))
             .header(CONTENT_LENGTH, content_length)
             .body(body)
             .send()


### PR DESCRIPTION
for some reason the base url now has a trailing slash, so calls to it that add a leading slash will end up calling `//rest/rpc`, with two slashes. i have no idea why this has changed, but this will fix cli installs.