### PR TITLE
Disable bluetooth properly #862

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -67,6 +67,7 @@ systemctl disable wpa_supplicant.service
 ln -rsf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 
 systemctl disable bluetooth.service
+systemctl disable hciuart.service
 systemctl disable triggerhappy.service
 
 apt-get autoremove -y


### PR DESCRIPTION
This should fix a long standing issue where the Bluetooth service was starting up at boot.

![image](https://user-images.githubusercontent.com/3073252/185498497-d07967b9-29c0-4754-9a2f-d85c118e92eb.png)

closes #862 
