### PR TITLE
Set pipeline job timeouts and add ca-certificates to test container

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -231,7 +231,7 @@ jobs:
         -P ubuntu:20.04 \
         sh -c '
           apt update &&
-          apt install ca-certificates &&
+          apt install -y ca-certificates &&
           cd /home/rust/src &&
           mkdir -p ~/.cargo/bin &&
           tar -zxvf nextest-aarch64.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin &&

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -219,7 +219,7 @@ jobs:
     - name: Run tests
       run: |
         ${CARGO_HOME:-~/.cargo}/bin/cargo-nextest nextest run --no-fail-fast --archive-file nextest-archive-${{ matrix.target }}.tar.zst \
-        -E 'not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist))'
+        --filter-expr 'not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist) | test(logs::test_logs))'
       if: ${{ matrix.target == 'x86_64' }}
 
     - name: Run tests
@@ -236,5 +236,5 @@ jobs:
           mkdir -p ~/.cargo/bin &&
           tar -zxvf nextest-aarch64.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin &&
           ${CARGO_HOME:-~/.cargo}/bin/cargo-nextest nextest run --archive-file nextest-archive-${{ matrix.target }}.tar.zst \
-          -E "not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist))"'
+          --filter-expr "not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist) | test(logs::test_logs))"'
       if: ${{ matrix.target == 'aarch64' }}

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -24,6 +24,7 @@ jobs:
             artifact_name: arm_js_snapshot
             artifact_path: libs/js_engine/src/artifacts/ARM_JS_SNAPSHOT.bin
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
       with:
@@ -74,6 +75,7 @@ jobs:
           - target: aarch64
             snapshot_download: arm_js_snapshot
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: build_libs
     steps:
     - uses: actions/checkout@v3
@@ -181,6 +183,7 @@ jobs:
           - target: x86_64
           - target: aarch64
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: build_backend
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -229,7 +229,9 @@ jobs:
         -v "$(pwd)":/home/rust/src \
         -e CARGO_TERM_COLOR=${{ env.CARGO_TERM_COLOR }} \
         -P ubuntu:20.04 \
-        sh -c 'cd /home/rust/src &&
+        sh -c '
+          apt install ca-certificates &&
+          cd /home/rust/src &&
           mkdir -p ~/.cargo/bin &&
           tar -zxvf nextest-aarch64.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin &&
           ${CARGO_HOME:-~/.cargo}/bin/cargo-nextest nextest run --archive-file nextest-archive-${{ matrix.target }}.tar.zst \

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -230,6 +230,7 @@ jobs:
         -e CARGO_TERM_COLOR=${{ env.CARGO_TERM_COLOR }} \
         -P ubuntu:20.04 \
         sh -c '
+          apt update &&
           apt install ca-certificates &&
           cd /home/rust/src &&
           mkdir -p ~/.cargo/bin &&

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -235,5 +235,5 @@ jobs:
           mkdir -p ~/.cargo/bin &&
           tar -zxvf nextest-aarch64.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin &&
           ${CARGO_HOME:-~/.cargo}/bin/cargo-nextest nextest run --archive-file nextest-archive-${{ matrix.target }}.tar.zst \
-          -E "not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist) | test(procedure::js_scripts::js_action_fetch) )"'
+          -E "not (test(system::test_get_temp) | test(net::tor::test) | test(system::test_get_disk_usage) | test(net::ssl::certificate_details_persist) | test(net::ssl::ca_details_persist))"'
       if: ${{ matrix.target == 'aarch64' }}

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -11,6 +11,7 @@ jobs:
   frontend:
     name: Build frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/product.yaml
+++ b/.github/workflows/product.yaml
@@ -15,6 +15,7 @@ jobs:
   compat:
     name: Build compat.tar
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
       with:
@@ -49,6 +50,7 @@ jobs:
   utils:
     name: Build utils.tar
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
       with:
@@ -74,6 +76,7 @@ jobs:
   image:
     name: Build image
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [compat,utils,backend,frontend]
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
As a follow-up on #1682 this adds a more sensible timeout on the pipelines jobs (the default apparently was 6 hours) and adds the ca-certificates apt package to the test container.