### PR TITLE
Bugfix/marketplace add

### DIFF
--- a/frontend/projects/ui/src/app/services/marketplace.service.ts
+++ b/frontend/projects/ui/src/app/services/marketplace.service.ts
@@ -37,8 +37,13 @@ export class MarketplaceService extends AbstractMarketplaceService {
   private readonly uiMarketplaceData$ = this.patch
     .watch$('ui', 'marketplace')
     .pipe(
+      filter(Boolean),
+      startWith({
+        'selected-id': null,
+        'known-hosts': {},
+      }),
       distinctUntilChanged(
-        (prev, curr) => prev?.['selected-id'] === curr?.['selected-id'],
+        (prev, curr) => prev['selected-id'] === curr['selected-id'],
       ),
       shareReplay(1),
     )
@@ -280,8 +285,8 @@ export class MarketplaceService extends AbstractMarketplaceService {
     }
   }
 
-  private toMarketplace(marketplace?: UIMarketplaceData): Marketplace {
-    return marketplace?.['selected-id']
+  private toMarketplace(marketplace: UIMarketplaceData): Marketplace {
+    return marketplace['selected-id']
       ? marketplace['known-hosts'][marketplace['selected-id']]
       : this.config.marketplace
   }

--- a/frontend/projects/ui/src/app/util/get-marketplace.ts
+++ b/frontend/projects/ui/src/app/util/get-marketplace.ts
@@ -3,10 +3,10 @@ import {
   DataModel,
   UIMarketplaceData,
 } from 'src/app/services/patch-db/data-model'
-import { filter, firstValueFrom } from 'rxjs'
+import { firstValueFrom } from 'rxjs'
 
 export function getMarketplace(
   patch: PatchDB<DataModel>,
 ): Promise<UIMarketplaceData> {
-  return firstValueFrom(patch.watch$('ui', 'marketplace').pipe(filter(Boolean)))
+  return firstValueFrom(patch.watch$('ui', 'marketplace'))
 }

--- a/frontend/projects/ui/src/app/util/get-marketplace.ts
+++ b/frontend/projects/ui/src/app/util/get-marketplace.ts
@@ -3,10 +3,18 @@ import {
   DataModel,
   UIMarketplaceData,
 } from 'src/app/services/patch-db/data-model'
-import { firstValueFrom } from 'rxjs'
+import { filter, firstValueFrom, startWith } from 'rxjs'
 
 export function getMarketplace(
   patch: PatchDB<DataModel>,
 ): Promise<UIMarketplaceData> {
-  return firstValueFrom(patch.watch$('ui', 'marketplace'))
+  return firstValueFrom(
+    patch.watch$('ui', 'marketplace').pipe(
+      filter(Boolean),
+      startWith({
+        'selected-id': null,
+        'known-hosts': {},
+      }),
+    ),
+  )
 }


### PR DESCRIPTION
Fixes a bug where no alt marketplaces could be added on a fresh install of eOS (ie. when only the default standard marketplace is in the list).

Bug exists due to no marketplaces key being present in the list, which will cause the adjusted function to return as falsey, thus never executing the rpc update call. 
<img width="1675" alt="Screen Shot 2022-09-15 at 10 36 33 AM" src="https://user-images.githubusercontent.com/12953208/190480964-97b5591d-4fac-455e-a132-1e2989a50fee.png">
