### PR TITLE
🧅 replace instead of adding tor repository

### DIFF
--- a/build/initialization.sh
+++ b/build/initialization.sh
@@ -54,8 +54,7 @@ apt-get install -y \
 	pgloader
 
 # Setup repository from The Guardian Project and install latest stable Tor daemon
-echo "deb     [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main" >> /etc/apt/sources.list.d/tor.list
-echo "deb-src [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main" >> /etc/apt/sources.list.d/tor.list
+echo "deb     [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main" > /etc/apt/sources.list.d/tor.list
 wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
 apt update && apt install -y tor deb.torproject.org-keyring
 


### PR DESCRIPTION
I also removed the src line because we won't use the tor source repository anytime soon if ever.