### PR TITLE
Bugfix/correctly package backend job

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -133,7 +133,7 @@ jobs:
       if: ${{ matrix.target == 'aarch64' }}
 
     - name: 'Tar files to preserve file permissions'
-      run: tar -cvf backend-${{ matrix.target }}.tar ENVIRONMENT.txt GIT_HASH.txt backend/target/${{ matrix.target }}-unknown-linux-gnu/release/embassy*
+      run: make backend-${{ matrix.target }}.tar
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -133,7 +133,7 @@ jobs:
       if: ${{ matrix.target == 'aarch64' }}
 
     - name: 'Tar files to preserve file permissions'
-      run: make backend-${{ matrix.target }}.tar
+      run: make ARCH=${{ matrix.target }} backend-${{ matrix.target }}.tar
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/product.yaml
+++ b/.github/workflows/product.yaml
@@ -13,83 +13,36 @@ on:
 
 jobs:
   compat:
-    name: Build compat.tar
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-
-    - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
-
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-compat-${{ hashFiles('**/system-images/compat/Cargo.lock') }}
-
-    - name: Build image
-      run: make system-images/compat/compat.tar
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: compat.tar
-        path: system-images/compat/compat.tar
+    uses: ./.github/workflows/reusable-workflow.yaml
+    with:
+      build_command: make system-images/compat/compat.tar
+      artifact_name: compat.tar
+      artifact_path: system-images/compat/compat.tar
 
   utils:
-    name: Build utils.tar
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-
-    - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
-
-    - name: Build image
-      run: make system-images/utils/utils.tar
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: utils.tar
-        path: system-images/utils/utils.tar
+    uses: ./.github/workflows/reusable-workflow.yaml
+    with:
+      build_command: make system-images/utils/utils.tar
+      artifact_name: utils.tar
+      artifact_path: system-images/utils/utils.tar
 
   binfmt:
-    name: Build binfmt.tar
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+    uses: ./.github/workflows/reusable-workflow.yaml
+    with:
+      build_command: make system-images/binfmt/binfmt.tar
+      artifact_name: binfmt.tar
+      artifact_path: system-images/binfmt/binfmt.tar
 
-    - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
-
-    - name: Build image
-      run: make system-images/binfmt/binfmt.tar
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: binfmt.tar
-        path: system-images/binfmt/binfmt.tar
+  nc-broadcast:
+    uses: ./.github/workflows/reusable-workflow.yaml
+    with:
+      build_command: make cargo-deps/aarch64-unknown-linux-gnu/release/nc-broadcast
+      artifact_name: nc-broadcast.tar
+      artifact_path: cargo-deps/aarch64-unknown-linux-gnu/release/nc-broadcast
 
   backend:
     uses: ./.github/workflows/backend.yaml
-  
+
   frontend:
     uses: ./.github/workflows/frontend.yaml
     
@@ -97,7 +50,7 @@ jobs:
     name: Build image
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [compat,utils,binfmt,backend,frontend]
+    needs: [compat,utils,binfmt,nc-broadcast,backend,frontend]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -120,6 +73,12 @@ jobs:
       with:
         name: binfmt.tar
         path: system-images/binfmt
+
+    - name: Download nc-broadcast.tar artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: nc-broadcast.tar
+        path: cargo-deps/aarch64-unknown-linux-gnu/release
 
     - name: Download js_snapshot artifact
       uses: actions/download-artifact@v3

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -1,0 +1,34 @@
+name: Reusable Workflow
+
+on:
+  workflow_call:
+    inputs:
+      build_command:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      artifact_path:
+        required: true
+        type: string
+
+jobs:
+  generic_build_job:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Set up Docker Buildx        
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build image
+      run: ${{ inputs.build_command }}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_path }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
+ARCH = aarch64
 ENVIRONMENT_FILE := $(shell ./check-environment.sh)
 GIT_HASH_FILE := $(shell ./check-git-hash.sh)
-EMBASSY_BINS := backend/target/aarch64-unknown-linux-gnu/release/embassyd backend/target/aarch64-unknown-linux-gnu/release/embassy-init backend/target/aarch64-unknown-linux-gnu/release/embassy-cli backend/target/aarch64-unknown-linux-gnu/release/embassy-sdk backend/target/aarch64-unknown-linux-gnu/release/avahi-alias
+EMBASSY_BINS := backend/target/$(ARCH)-unknown-linux-gnu/release/embassyd backend/target/$(ARCH)-unknown-linux-gnu/release/embassy-init backend/target/$(ARCH)-unknown-linux-gnu/release/embassy-cli backend/target/$(ARCH)-unknown-linux-gnu/release/embassy-sdk backend/target/$(ARCH)-unknown-linux-gnu/release/avahi-alias
 EMBASSY_UIS := frontend/dist/ui frontend/dist/setup-wizard frontend/dist/diagnostic-ui
 EMBASSY_SRC := raspios.img product_key.txt $(EMBASSY_BINS) backend/embassyd.service backend/embassy-init.service $(EMBASSY_UIS) $(shell find build)
 COMPAT_SRC := $(shell find system-images/compat/ -not -path 'system-images/compat/target/*' -and -not -name compat.tar -and -not -name target)
@@ -101,11 +102,7 @@ patch-db/client/dist: $(PATCH_DB_CLIENT_SRC) patch-db/client/node_modules
 	npm --prefix frontend run build:deps
 
 # used by github actions
-backend-x86_64.tar: $(ENVIRONMENT_FILE) $(GIT_HASH_FILE) $(EMBASSY_BINS)
-	tar -cvf $@ $^
-
-# used by github actions
-backend-aarch64.tar: $(ENVIRONMENT_FILE) $(GIT_HASH_FILE) $(EMBASSY_BINS)
+backend-$(ARCH).tar: $(ENVIRONMENT_FILE) $(GIT_HASH_FILE) $(EMBASSY_BINS)
 	tar -cvf $@ $^
 
 # this is a convenience step to build all frontends - it is not referenced elsewhere in this file

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ $(shell sudo true)
 
 .DELETE_ON_ERROR:
 
+.PHONY: all gzip clean format sdk snapshots frontends ui backend
 all: eos.img
 
 gzip: eos.tar.gz
@@ -99,13 +100,21 @@ patch-db/client/dist: $(PATCH_DB_CLIENT_SRC) patch-db/client/node_modules
 	! test -d patch-db/client/dist || rm -rf patch-db/client/dist
 	npm --prefix frontend run build:deps
 
+# used by github actions
+backend-x86_64.tar: $(ENVIRONMENT_FILE) $(GIT_HASH_FILE) $(EMBASSY_BINS)
+	tar -cvf $@ $^
+
+# used by github actions
+backend-aarch64.tar: $(ENVIRONMENT_FILE) $(GIT_HASH_FILE) $(EMBASSY_BINS)
+	tar -cvf $@ $^
+
 # this is a convenience step to build all frontends - it is not referenced elsewhere in this file
 frontends: $(EMBASSY_UIS) 
 
 # this is a convenience step to build the UI
 ui: frontend/dist/ui
 
-# this is a convenience step to build the backend
+# used by github actions
 backend: $(EMBASSY_BINS)
 
 cargo-deps/aarch64-unknown-linux-gnu/release/nc-broadcast:


### PR DESCRIPTION
As mentioned in #1789 this PR changes:
* Use the makefile for packaging the backend -> fixing the backend compile in image job issue
* Pre-build nc-broadcast instead of doing this in the image job
* Remove some duplication from the pipeline by moving parts into a generic workflow
