### PR TITLE
Update build pipeline

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -107,7 +107,9 @@ jobs:
         key: ${{ runner.os }}-cargo-backend-${{ matrix.target }}-${{ hashFiles('backend/Cargo.lock') }}
 
     - name: Install dependencies
-      run: sudo apt-get install libavahi-client-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libavahi-client-dev
       if: ${{ matrix.target == 'x86_64' }}
 
     - name: Check Git Hash

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -31,11 +31,11 @@ jobs:
         submodules: recursive
         
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       if: ${{ matrix.target == 'aarch64' }}
       
     - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       if: ${{ matrix.target == 'aarch64' }}
 
     - uses: actions-rs/toolchain@v1
@@ -193,11 +193,11 @@ jobs:
         submodules: recursive
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       if: ${{ matrix.target == 'aarch64' }}
 
     - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       if: ${{ matrix.target == 'aarch64' }}
 
     - run: mkdir -p ~/.cargo/bin

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -38,10 +38,11 @@ jobs:
       uses: docker/setup-buildx-action@v2
       if: ${{ matrix.target == 'aarch64' }}
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.RUST_VERSION }}
-        override: true
+    - name: "Install Rust"
+      run: |
+        rustup toolchain install ${{ env.RUST_VERSION }} --profile minimal --no-self-update
+        rustup default ${{ inputs.rust }}
+      shell: bash
       if: ${{ matrix.target == 'x86_64' }}
     
     - uses: actions/cache@v3
@@ -88,10 +89,11 @@ jobs:
         name: ${{ matrix.snapshot_download }}
         path: libs/js_engine/src/artifacts/
         
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.RUST_VERSION }}
-        override: true
+    - name: "Install Rust"
+      run: |
+        rustup toolchain install ${{ env.RUST_VERSION }} --profile minimal --no-self-update
+        rustup default ${{ inputs.rust }}
+      shell: bash
       if: ${{ matrix.target == 'x86_64' }}
     
     - uses: actions/cache@v3

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -234,8 +234,8 @@ jobs:
         -e CARGO_TERM_COLOR=${{ env.CARGO_TERM_COLOR }} \
         -P ubuntu:20.04 \
         sh -c '
-          apt update &&
-          apt install -y ca-certificates &&
+          apt-get update &&
+          apt-get install -y ca-certificates &&
           cd /home/rust/src &&
           mkdir -p ~/.cargo/bin &&
           tar -zxvf nextest-aarch64.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin &&

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache-dir
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "name=dir::$(npm config get cache)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v3
       id: npm-cache
       with:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache-dir
       run: |
-        echo "name=dir::$(npm config get cache)" >> $GITHUB_OUTPUT
+        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v3
       id: npm-cache
       with:

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -23,7 +23,7 @@ jobs:
         submodules: recursive
 
     - name: Set up Docker Buildx        
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Build image
       run: ${{ inputs.build_command }}


### PR DESCRIPTION
This PR fixes the current errors and warnings in the build pipeline. The changes are:
* Update the version of some actions to fix the recent warnings (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ and https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
* Run apt-get update before apt-get install in the backend pipeline to fix a build error
* Replace actions-rs/toolchain with a bash script because it's throwing a warning and hasn't been updated in a while