### PR TITLE
fix migration to support portable fatties

### DIFF
--- a/backend/src/init.rs
+++ b/backend/src/init.rs
@@ -10,7 +10,7 @@ use tokio::process::Command;
 
 use crate::context::rpc::RpcContextConfig;
 use crate::db::model::ServerStatus;
-use crate::install::PKG_DOCKER_DIR;
+use crate::install::PKG_ARCHIVE_DIR;
 use crate::sound::CIRCLE_OF_5THS_SHORT;
 use crate::util::Invoke;
 use crate::Error;
@@ -292,7 +292,7 @@ pub async fn init(cfg: &RpcContextConfig) -> Result<InitResult, Error> {
         tracing::info!("Loaded System Docker Images");
 
         tracing::info!("Loading Package Docker Images");
-        crate::install::load_images(cfg.datadir().join(PKG_DOCKER_DIR)).await?;
+        crate::install::load_images(cfg.datadir().join(PKG_ARCHIVE_DIR)).await?;
         tracing::info!("Loaded Package Docker Images");
     }
 

--- a/backend/src/install/cleanup.rs
+++ b/backend/src/install/cleanup.rs
@@ -5,7 +5,7 @@ use patch_db::{DbHandle, LockReceipt, LockTargetId, LockType, PatchDbHandle, Ver
 use sqlx::{Executor, Postgres};
 use tracing::instrument;
 
-use super::{PKG_ARCHIVE_DIR, PKG_DOCKER_DIR};
+use super::PKG_ARCHIVE_DIR;
 use crate::config::{not_found, ConfigReceipts};
 use crate::context::RpcContext;
 use crate::db::model::{
@@ -142,16 +142,6 @@ pub async fn cleanup(ctx: &RpcContext, id: &PackageId, version: &Version) -> Res
         .join(version.as_str());
     if tokio::fs::metadata(&pkg_archive_dir).await.is_ok() {
         tokio::fs::remove_dir_all(&pkg_archive_dir)
-            .await
-            .apply(|res| errors.handle(res));
-    }
-    let docker_path = ctx
-        .datadir
-        .join(PKG_DOCKER_DIR)
-        .join(id)
-        .join(version.as_str());
-    if tokio::fs::metadata(&docker_path).await.is_ok() {
-        tokio::fs::remove_dir_all(&docker_path)
             .await
             .apply(|res| errors.handle(res));
     }

--- a/backend/src/setup.rs
+++ b/backend/src/setup.rs
@@ -410,6 +410,7 @@ pub async fn execute_inner(
                 delete: true,
                 force: true,
                 ignore_existing: false,
+                exclude: Vec::new(),
             },
         )?
         .wait()
@@ -429,6 +430,7 @@ pub async fn execute_inner(
                 delete: true,
                 force: true,
                 ignore_existing: false,
+                exclude: vec!["tmp".to_owned()],
             },
         )?;
         *ctx.recovery_status.write().await = Some(Ok(RecoveryStatus {

--- a/backend/src/setup.rs
+++ b/backend/src/setup.rs
@@ -81,7 +81,6 @@ async fn setup_init(
     ctx: &SetupContext,
     password: Option<String>,
 ) -> Result<(Hostname, OnionAddressV3, X509), Error> {
-    init(&RpcContextConfig::load(ctx.config_path.clone()).await?).await?;
     let secrets = ctx.secret_store().await?;
     let db = ctx.db(&secrets).await?;
     let mut secrets_handle = secrets.acquire().await?;
@@ -159,6 +158,7 @@ pub async fn attach(
         ));
     }
     let (hostname, tor_addr, root_ca) = setup_init(&ctx, password).await?;
+    init(&RpcContextConfig::load(ctx.config_path.clone()).await?).await?;
     let setup_result = SetupResult {
         tor_address: format!("http://{}", tor_addr),
         lan_address: hostname.lan_address(),
@@ -450,6 +450,7 @@ pub async fn execute_inner(
                     }));
                 }
                 package_data_transfer.wait().await?;
+                init(&RpcContextConfig::load(ctx.config_path.clone()).await?).await?;
                 Ok::<_, Error>(())
             }
             .and_then(|_| async {

--- a/backend/src/update/mod.rs
+++ b/backend/src/update/mod.rs
@@ -320,6 +320,7 @@ async fn sync_boot() -> Result<(), Error> {
             delete: false,
             force: false,
             ignore_existing: true,
+            exclude: Vec::new(),
         },
     )?
     .wait()

--- a/libs/helpers/src/lib.rs
+++ b/libs/helpers/src/lib.rs
@@ -16,6 +16,10 @@ pub use byte_replacement_reader::*;
 pub use rsync::*;
 pub use script_dir::*;
 
+pub fn const_true() -> bool {
+    true
+}
+
 pub fn to_tmp_path(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
     let path = path.as_ref();
     if let (Some(parent), Some(file_name)) =

--- a/libs/helpers/src/rsync.rs
+++ b/libs/helpers/src/rsync.rs
@@ -14,6 +14,7 @@ pub struct RsyncOptions {
     pub delete: bool,
     pub force: bool,
     pub ignore_existing: bool,
+    pub exclude: Vec<String>,
 }
 impl Default for RsyncOptions {
     fn default() -> Self {
@@ -21,6 +22,7 @@ impl Default for RsyncOptions {
             delete: true,
             force: true,
             ignore_existing: false,
+            exclude: Vec::new(),
         }
     }
 }
@@ -46,6 +48,9 @@ impl Rsync {
         }
         if options.ignore_existing {
             cmd.arg("--ignore-existing");
+        }
+        for exclude in options.exclude {
+            cmd.arg(format!("--exclude={}", exclude));
         }
         let mut command = cmd
             .arg("-ac")

--- a/libs/helpers/src/rsync.rs
+++ b/libs/helpers/src/rsync.rs
@@ -1,7 +1,7 @@
 use color_eyre::eyre::eyre;
 use std::path::Path;
 
-use crate::{ByteReplacementReader, NonDetachingJoinHandle};
+use crate::{const_true, ByteReplacementReader, NonDetachingJoinHandle};
 use models::{Error, ErrorKind};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::process::{Child, Command};
@@ -11,9 +11,13 @@ use tokio_stream::wrappers::WatchStream;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RsyncOptions {
+    #[serde(default = "const_true")]
     pub delete: bool,
+    #[serde(default = "const_true")]
     pub force: bool,
+    #[serde(default)]
     pub ignore_existing: bool,
+    #[serde(default)]
     pub exclude: Vec<String>,
 }
 impl Default for RsyncOptions {


### PR DESCRIPTION
This way, migrating a data drive to a new arch will seamlessly switch to using containers from the target arch.