### PR TITLE
Update/marketplace info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ frontend/dist/install-wizard: $(FRONTEND_INSTALL_WIZARD_SRC) $(FRONTEND_SHARED_S
 
 frontend/config.json: $(GIT_HASH_FILE) frontend/config-sample.json
 	jq '.useMocks = false' frontend/config-sample.json > frontend/config.json
-	jq '.targetArch = $(ARCH)' frontend/config.json > frontend/config.json.tmp
+	jq '.targetArch = "$(ARCH)"' frontend/config.json > frontend/config.json.tmp
 	mv frontend/config.json.tmp frontend/config.json
 	npm --prefix frontend run-script build-config
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-ARCH = $(shell uname -m)
+RASPI_TARGETS := embassyos-raspi.img embassyos-raspi.tar.gz gzip lite-upgrade.img
+ARCH := $(shell if echo $(RASPI_TARGETS) | grep -qw "$(MAKECMDGOALS)"; then echo aarch64; else uname -m; fi)
+OS_ARCH := $(shell if echo $(RASPI_TARGETS) | grep -qw "$(MAKECMDGOALS)"; then echo raspberrypi; else uname -m; fi)
 ENVIRONMENT_FILE = $(shell ./check-environment.sh)
 GIT_HASH_FILE = $(shell ./check-git-hash.sh)
 VERSION_FILE = $(shell ./check-version.sh)

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,8 @@ frontend/dist/install-wizard: $(FRONTEND_INSTALL_WIZARD_SRC) $(FRONTEND_SHARED_S
 
 frontend/config.json: $(GIT_HASH_FILE) frontend/config-sample.json
 	jq '.useMocks = false' frontend/config-sample.json > frontend/config.json
+	jq '.targetArch = $(ARCH)' frontend/config.json > frontend/config.json.tmp
+	mv frontend/config.json.tmp frontend/config.json
 	npm --prefix frontend run-script build-config
 
 frontend/patchdb-ui-seed.json: frontend/package.json

--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,9 @@ frontend/dist/install-wizard: $(FRONTEND_INSTALL_WIZARD_SRC) $(FRONTEND_SHARED_S
 
 frontend/config.json: $(GIT_HASH_FILE) frontend/config-sample.json
 	jq '.useMocks = false' frontend/config-sample.json > frontend/config.json
-	jq '.targetArch = "$(ARCH)"' frontend/config.json > frontend/config.json.tmp
-	mv frontend/config.json.tmp frontend/config.json
+	jq '.packageArch = "$(ARCH)"' frontend/config.json > frontend/config.json.tmp
+	jq '.osArch = "$(OS_ARCH)"' frontend/config.json.tmp > frontend/config.json
+	rm frontend/config.json.tmp
 	npm --prefix frontend run-script build-config
 
 frontend/patchdb-ui-seed.json: frontend/package.json

--- a/frontend/config-sample.json
+++ b/frontend/config-sample.json
@@ -1,6 +1,7 @@
 {
   "useMocks": true,
-  "targetArch": "aarch64",
+  "packageArch": "aarch64",
+  "osArch": "rasberrypi",
   "ui": {
     "api": {
       "url": "rpc",

--- a/frontend/projects/shared/src/types/workspace-config.ts
+++ b/frontend/projects/shared/src/types/workspace-config.ts
@@ -1,5 +1,6 @@
 export type WorkspaceConfig = {
-  targetArch: 'aarch64' | 'x86_64'
+  packageArch: 'aarch64' | 'x86_64'
+  osArch: 'aarch64' | 'x86_64' | 'raspberrypi'
   gitHash: string
   useMocks: boolean
   // each key corresponds to a project and values adjust settings for that project, eg: ui, install-wizard, setup-wizard, diagnostic-ui

--- a/frontend/projects/ui/src/app/modals/os-update/os-update.page.ts
+++ b/frontend/projects/ui/src/app/modals/os-update/os-update.page.ts
@@ -3,8 +3,6 @@ import { LoadingController, ModalController } from '@ionic/angular'
 import { ApiService } from '../../services/api/embassy-api.service'
 import { ErrorToastService } from '@start9labs/shared'
 import { EOSService } from 'src/app/services/eos.service'
-import { PatchDB } from 'patch-db-client'
-import { DataModel } from 'src/app/services/patch-db/data-model'
 
 @Component({
   selector: 'os-update',
@@ -21,7 +19,6 @@ export class OSUpdatePage {
     private readonly errToast: ErrorToastService,
     private readonly embassyApi: ApiService,
     private readonly eosService: EOSService,
-    private readonly patch: PatchDB<DataModel>,
   ) {}
 
   ngOnInit() {

--- a/frontend/projects/ui/src/app/pages/server-routes/server-show/server-show.page.ts
+++ b/frontend/projects/ui/src/app/pages/server-routes/server-show/server-show.page.ts
@@ -308,11 +308,11 @@ export class ServerShowPage {
     await loader.present()
 
     try {
-      const updateAvailable = await this.eosService.getEOS()
+      await this.eosService.loadEos()
 
       await loader.dismiss()
 
-      if (updateAvailable) {
+      if (this.eosService.updateAvailable$.value) {
         this.updateEos()
       } else {
         this.presentAlertLatest()

--- a/frontend/projects/ui/src/app/services/api/api.fixures.ts
+++ b/frontend/projects/ui/src/app/services/api/api.fixures.ts
@@ -19,7 +19,7 @@ export module Mock {
     'update-progress': null,
     updated: true,
   }
-  export const MarketplaceEos: RR.GetMarketplaceEOSRes = {
+  export const MarketplaceEos: RR.GetMarketplaceEosRes = {
     version: '0.3.3',
     headline: 'Our biggest release ever.',
     'release-notes': {

--- a/frontend/projects/ui/src/app/services/api/api.types.ts
+++ b/frontend/projects/ui/src/app/services/api/api.types.ts
@@ -244,15 +244,15 @@ export module RR {
 
   // marketplace
 
-  export type ServerInfo = {
+  export type EnvInfo = {
     'server-id': string
     'eos-version': string
   }
-  export type GetMarketplaceInfoReq = ServerInfo
+  export type GetMarketplaceInfoReq = EnvInfo
   export type GetMarketplaceInfoRes = StoreInfo
 
-  export type GetMarketplaceEOSReq = ServerInfo
-  export type GetMarketplaceEOSRes = MarketplaceEOS
+  export type GetMarketplaceEosReq = EnvInfo
+  export type GetMarketplaceEosRes = MarketplaceEOS
 
   export type GetMarketplacePackagesReq = {
     ids?: { id: string; version: string }[]

--- a/frontend/projects/ui/src/app/services/api/api.types.ts
+++ b/frontend/projects/ui/src/app/services/api/api.types.ts
@@ -244,13 +244,14 @@ export module RR {
 
   // marketplace
 
-  export type GetMarketplaceInfoReq = { 'server-id': string }
-  export type GetMarketplaceInfoRes = StoreInfo
-
-  export type GetMarketplaceEOSReq = {
+  export type ServerInfo = {
     'server-id': string
     'eos-version': string
   }
+  export type GetMarketplaceInfoReq = ServerInfo
+  export type GetMarketplaceInfoRes = StoreInfo
+
+  export type GetMarketplaceEOSReq = ServerInfo
   export type GetMarketplaceEOSRes = MarketplaceEOS
 
   export type GetMarketplacePackagesReq = {

--- a/frontend/projects/ui/src/app/services/api/embassy-api.service.ts
+++ b/frontend/projects/ui/src/app/services/api/embassy-api.service.ts
@@ -101,7 +101,7 @@ export abstract class ApiService {
 
   abstract marketplaceProxy<T>(
     path: string,
-    params: {},
+    params: Record<string, unknown>,
     url: string,
     arch?: string,
   ): Promise<T>

--- a/frontend/projects/ui/src/app/services/api/embassy-api.service.ts
+++ b/frontend/projects/ui/src/app/services/api/embassy-api.service.ts
@@ -103,11 +103,10 @@ export abstract class ApiService {
     path: string,
     params: {},
     url: string,
+    arch?: string,
   ): Promise<T>
 
-  abstract getEos(
-    params: RR.GetMarketplaceEOSReq,
-  ): Promise<RR.GetMarketplaceEOSRes>
+  abstract getEos(): Promise<RR.GetMarketplaceEosRes>
 
   // password
   // abstract updatePassword (params: RR.UpdatePasswordReq): Promise<RR.UpdatePasswordRes>

--- a/frontend/projects/ui/src/app/services/api/embassy-live-api.service.ts
+++ b/frontend/projects/ui/src/app/services/api/embassy-live-api.service.ts
@@ -19,6 +19,7 @@ import { AuthService } from '../auth.service'
 import { DOCUMENT } from '@angular/common'
 import { DataModel } from '../patch-db/data-model'
 import { PatchDB, pathFromArray, Update } from 'patch-db-client'
+import { getServerInfo } from 'src/app/util/get-server-info'
 
 @Injectable()
 export class LiveApiService extends ApiService {
@@ -177,8 +178,13 @@ export class LiveApiService extends ApiService {
 
   // marketplace URLs
 
-  async marketplaceProxy<T>(path: string, qp: {}, baseUrl: string): Promise<T> {
-    Object.assign(qp, { arch: this.config.targetArch })
+  async marketplaceProxy<T>(
+    path: string,
+    qp: {},
+    baseUrl: string,
+    arch: string = this.config.packageArch,
+  ): Promise<T> {
+    Object.assign(qp, { arch })
     const fullUrl = `${baseUrl}${path}?${new URLSearchParams(qp).toString()}`
     return this.rpcRequest({
       method: 'marketplace.get',
@@ -186,13 +192,18 @@ export class LiveApiService extends ApiService {
     })
   }
 
-  async getEos(
-    params: RR.GetMarketplaceEOSReq,
-  ): Promise<RR.GetMarketplaceEOSRes> {
+  async getEos(): Promise<RR.GetMarketplaceEosRes> {
+    const { id, version } = await getServerInfo(this.patch)
+    const qp: RR.GetMarketplaceEosReq = {
+      'server-id': id,
+      'eos-version': version,
+    }
+
     return this.marketplaceProxy(
       '/eos/v0/latest',
-      params,
+      qp,
       this.config.marketplace.start9,
+      this.config.osArch,
     )
   }
 

--- a/frontend/projects/ui/src/app/services/api/embassy-live-api.service.ts
+++ b/frontend/projects/ui/src/app/services/api/embassy-live-api.service.ts
@@ -180,11 +180,12 @@ export class LiveApiService extends ApiService {
 
   async marketplaceProxy<T>(
     path: string,
-    qp: {},
+    qp: Record<string, string>,
     baseUrl: string,
     arch: string = this.config.packageArch,
   ): Promise<T> {
-    Object.assign(qp, { arch })
+    // Object.assign(qp, { arch })
+    qp['arch'] = arch
     const fullUrl = `${baseUrl}${path}?${new URLSearchParams(qp).toString()}`
     return this.rpcRequest({
       method: 'marketplace.get',

--- a/frontend/projects/ui/src/app/services/api/embassy-mock-api.service.ts
+++ b/frontend/projects/ui/src/app/services/api/embassy-mock-api.service.ts
@@ -296,7 +296,7 @@ export class MockApiService extends ApiService {
 
   async marketplaceProxy(
     path: string,
-    params: {},
+    params: Record<string, string>,
     url: string,
     arch = '',
   ): Promise<any> {

--- a/frontend/projects/ui/src/app/services/api/embassy-mock-api.service.ts
+++ b/frontend/projects/ui/src/app/services/api/embassy-mock-api.service.ts
@@ -294,7 +294,12 @@ export class MockApiService extends ApiService {
 
   // marketplace URLs
 
-  async marketplaceProxy(path: string, params: {}, url: string): Promise<any> {
+  async marketplaceProxy(
+    path: string,
+    params: {},
+    url: string,
+    arch = '',
+  ): Promise<any> {
     await pauseFor(2000)
 
     if (path === '/package/v0/info') {
@@ -320,9 +325,7 @@ export class MockApiService extends ApiService {
     }
   }
 
-  async getEos(
-    params: RR.GetMarketplaceEOSReq,
-  ): Promise<RR.GetMarketplaceEOSRes> {
+  async getEos(): Promise<RR.GetMarketplaceEosRes> {
     await pauseFor(2000)
     return Mock.MarketplaceEos
   }

--- a/frontend/projects/ui/src/app/services/config.service.ts
+++ b/frontend/projects/ui/src/app/services/config.service.ts
@@ -9,7 +9,8 @@ import {
 } from 'src/app/services/patch-db/data-model'
 
 const {
-  targetArch,
+  packageArch,
+  osArch,
   gitHash,
   useMocks,
   ui: { api, marketplace, mocks },
@@ -25,7 +26,8 @@ export class ConfigService {
   version = require('../../../../../package.json').version as string
   useMocks = useMocks
   mocks = mocks
-  targetArch = targetArch
+  packageArch = packageArch
+  osArch = osArch
   gitHash = gitHash
   api = api
   marketplace = marketplace

--- a/frontend/projects/ui/src/app/services/eos.service.ts
+++ b/frontend/projects/ui/src/app/services/eos.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core'
 import { Emver } from '@start9labs/shared'
 import { BehaviorSubject, combineLatest } from 'rxjs'
 import { distinctUntilChanged, map } from 'rxjs/operators'
-
 import { MarketplaceEOS } from 'src/app/services/api/api.types'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
 import { PatchDB } from 'patch-db-client'
@@ -52,14 +51,10 @@ export class EOSService {
     private readonly patch: PatchDB<DataModel>,
   ) {}
 
-  async getEOS(): Promise<boolean> {
-    const { id, version } = await getServerInfo(this.patch)
-    this.eos = await this.api.getEos({
-      'server-id': id,
-      'eos-version': version,
-    })
+  async loadEos(): Promise<void> {
+    const { version } = await getServerInfo(this.patch)
+    this.eos = await this.api.getEos()
     const updateAvailable = this.emver.compare(this.eos.version, version) === 1
     this.updateAvailable$.next(updateAvailable)
-    return updateAvailable
   }
 }

--- a/frontend/projects/ui/src/app/services/marketplace.service.ts
+++ b/frontend/projects/ui/src/app/services/marketplace.service.ts
@@ -169,17 +169,18 @@ export class MarketplaceService implements AbstractMarketplaceService {
   }
 
   fetchInfo$(url: string): Observable<StoreInfo> {
-    return this.patch
-      .watch$('server-info', 'id')
-      .pipe(
-        switchMap(id =>
-          this.api.marketplaceProxy<RR.GetMarketplaceInfoRes>(
-            '/package/v0/info',
-            { 'server-d': id },
-            url,
-          ),
+    return this.patch.watch$('server-info').pipe(
+      switchMap(serverInfo =>
+        this.api.marketplaceProxy<RR.GetMarketplaceInfoRes>(
+          '/package/v0/info',
+          {
+            'server-id': serverInfo.id,
+            'eos-version': serverInfo.version,
+          },
+          url,
         ),
-      )
+      ),
+    )
   }
 
   private fetchStore$(url: string): Observable<StoreData | null> {

--- a/frontend/projects/ui/src/app/services/marketplace.service.ts
+++ b/frontend/projects/ui/src/app/services/marketplace.service.ts
@@ -170,16 +170,17 @@ export class MarketplaceService implements AbstractMarketplaceService {
 
   fetchInfo$(url: string): Observable<StoreInfo> {
     return this.patch.watch$('server-info').pipe(
-      switchMap(serverInfo =>
-        this.api.marketplaceProxy<RR.GetMarketplaceInfoRes>(
+      switchMap(serverInfo => {
+        const qp: RR.GetMarketplaceInfoReq = {
+          'server-id': serverInfo.id,
+          'eos-version': serverInfo.version,
+        }
+        return this.api.marketplaceProxy<RR.GetMarketplaceInfoRes>(
           '/package/v0/info',
-          {
-            'server-id': serverInfo.id,
-            'eos-version': serverInfo.version,
-          },
+          qp,
           url,
-        ),
-      ),
+        )
+      }),
     )
   }
 

--- a/frontend/projects/ui/src/app/services/patch-data.service.ts
+++ b/frontend/projects/ui/src/app/services/patch-data.service.ts
@@ -44,7 +44,7 @@ export class PatchDataService extends Observable<DataModel> {
   }
 
   private checkForUpdates(): void {
-    this.eosService.getEOS()
+    this.eosService.loadEos()
     this.marketplaceService.getMarketplace$().pipe(take(1)).subscribe()
   }
 


### PR DESCRIPTION
This PR updates the marketplace info endpoint to include eos version with the request and ensures that the system architecture is always accurate and present in config so that the registry can use this information to log metrics.