### PR TITLE
fix: Manager's exit not stopping

### DIFF
--- a/backend/src/manager/mod.rs
+++ b/backend/src/manager/mod.rs
@@ -327,7 +327,6 @@ impl Manager {
             }) => (), // Already stopped
             a => a?,
         };
-
         self.shared.killer.notify_waiters();
 
         if let Some(thread) = self.thread.take().await {
@@ -644,9 +643,23 @@ async fn get_running_ip(
         if let Poll::Ready(res) = futures::poll!(&mut runtime) {
             match res {
                 Ok(Ok(response)) => return GetRunningIp::EarlyExit(response),
-                Err(_) | Ok(Err(_)) => {
+                Err(e) => {
                     return GetRunningIp::Error(Error::new(
-                        eyre!("Manager runtime panicked!"),
+                        match e.try_into_panic() {
+                            Ok(e) => {
+                                eyre!(
+                                    "Manager runtime panicked: {}",
+                                    e.downcast_ref::<&'static str>().unwrap_or(&"UNKNOWN")
+                                )
+                            }
+                            _ => eyre!("Manager runtime cancelled!"),
+                        },
+                        crate::ErrorKind::Docker,
+                    ))
+                }
+                Ok(Err(e)) => {
+                    return GetRunningIp::Error(Error::new(
+                        eyre!("Manager runtime returned error: {}", e),
                         crate::ErrorKind::Docker,
                     ))
                 }
@@ -772,12 +785,11 @@ async fn stop(shared: &ManagerSharedState) -> Result<(), Error> {
     shared
         .commit_health_check_results
         .store(false, Ordering::SeqCst);
-    shared.on_stop.send(OnStop::Sleep).map_err(|_| {
-        Error::new(
-            eyre!("Manager has already been shutdown"),
-            crate::ErrorKind::Docker,
-        )
-    })?;
+    shared.on_stop.send_modify(|status| {
+        if matches!(*status, OnStop::Restart) {
+            *status = OnStop::Sleep;
+        }
+    });
     if *shared.status.1.borrow() == Status::Paused {
         resume(shared).await?;
     }
@@ -794,12 +806,11 @@ async fn stop(shared: &ManagerSharedState) -> Result<(), Error> {
 
 #[instrument(skip(shared))]
 async fn start(shared: &ManagerSharedState) -> Result<(), Error> {
-    shared.on_stop.send(OnStop::Restart).map_err(|_| {
-        Error::new(
-            eyre!("Manager has already been shutdown"),
-            crate::ErrorKind::Docker,
-        )
-    })?;
+    shared.on_stop.send_modify(|status| {
+        if matches!(*status, OnStop::Sleep) {
+            *status = OnStop::Restart;
+        }
+    });
     let _ = shared.status.0.send_modify(|x| {
         if *x != Status::Running {
             *x = Status::Starting


### PR DESCRIPTION
## About - Bad flow

We start with a running searxng.
Then we go and upgrade this service. 
Issue: During the installation process we see it get stuck in the installation state.

## About - Reason

The synchronizer is converting the service from killed -> sleep.
Also there is a state machine hell in this service.

## Proof 
Video showing that the `about - bad flow` is no longer recreatable.
Note: This still takes a long time since we are waiting for a timeout in the process of the searxng.
https://user-images.githubusercontent.com/2364004/211415883-675994cb-df72-4c97-a40a-89a63de8e158.mp4


