### PR TITLE
fix: Zero op new dir dies.

### DIFF
--- a/backend/src/procedure/js_scripts.rs
+++ b/backend/src/procedure/js_scripts.rs
@@ -554,6 +554,51 @@ async fn js_action_test_deep_dir_escape() {
         .unwrap()
         .unwrap();
 }
+#[tokio::test]
+async fn js_action_test_zero_dir() {
+    let js_action = JsProcedure { args: vec![] };
+    let path: PathBuf = "test/js_action_execute/"
+        .parse::<PathBuf>()
+        .unwrap()
+        .canonicalize()
+        .unwrap();
+    let package_id = "test-package".parse().unwrap();
+    let package_version: Version = "0.3.0.3".parse().unwrap();
+    let name = ProcedureName::Action("test-zero-dir".parse().unwrap());
+    let volumes: Volumes = serde_json::from_value(serde_json::json!({
+        "main": {
+            "type": "data"
+        },
+        "compat": {
+            "type": "assets"
+        },
+        "filebrowser" :{
+            "package-id": "filebrowser",
+            "path": "data",
+            "readonly": true,
+            "type": "pointer",
+            "volume-id": "main",
+        }
+    }))
+    .unwrap();
+    let input: Option<serde_json::Value> = None;
+    let timeout = Some(Duration::from_secs(10));
+    js_action
+        .execute::<serde_json::Value, serde_json::Value>(
+            &path,
+            &package_id,
+            &package_version,
+            name,
+            &volumes,
+            input,
+            timeout,
+            ProcessGroupId(0),
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+}
 
 #[tokio::test]
 async fn js_rsync() {

--- a/backend/test/js_action_execute/package-data/scripts/test-package/0.3.0.3/embassy.js
+++ b/backend/test/js_action_execute/package-data/scripts/test-package/0.3.0.3/embassy.js
@@ -889,6 +889,28 @@ export const action = {
     };
   },
   /**
+   * Created this test because of issue
+   * https://github.com/Start9Labs/embassy-os/issues/2121
+   * That the empty in the create dies
+   * @param {*} effects 
+   * @param {*} _input 
+   * @returns 
+   */
+  async "test-zero-dir"(effects, _input) {
+    await effects.createDir({
+      volumeId: "main",
+      path: "./",
+    });
+    return {
+      result: {
+        copyable: false,
+        message: "Done",
+        version: "0",
+        qr: false,
+      },
+    };
+  },
+  /**
    * Found case where we could escape with the new deeper dir fix.
    * @param {*} effects 
    * @param {*} _input 

--- a/libs/js_engine/src/lib.rs
+++ b/libs/js_engine/src/lib.rs
@@ -832,11 +832,9 @@ mod fns {
             bail!("Volume {} is readonly", volume_id);
         }
         let new_file = volume_path.join(path_in);
-        let parent_new_file = new_file
-            .parent()
-            .ok_or_else(|| anyhow!("Expecting that file is not root"))?;
+
         // With the volume check
-        if !is_subset(&volume_path, &parent_new_file).await? {
+        if !is_subset(&volume_path, &new_file).await? {
             bail!(
                 "Path '{}' has broken away from parent '{}'",
                 new_file.to_string_lossy(),


### PR DESCRIPTION
Fixes : #2121 

### Proof of fixed
Recreated the broken situation in the test.
Then fixed, it was that we where checking the parent. Makes sense that was wrong