### PR TITLE
Always invoke fdisk with `sudo fdisk` in build/raspberry-pi/make-image.sh

### DIFF
--- a/build/raspberry-pi/make-image.sh
+++ b/build/raspberry-pi/make-image.sh
@@ -24,7 +24,7 @@ truncate -s $TARGET_SIZE $TARGET_NAME
     echo 532480
     echo
     echo w
-) | fdisk $TARGET_NAME
+) | sudo fdisk $TARGET_NAME
 export OUTPUT_DEVICE=$(sudo losetup --show -fP $TARGET_NAME)
 sudo e2fsck -f -y `partition_for ${OUTPUT_DEVICE} 2`
 sudo resize2fs `partition_for ${OUTPUT_DEVICE} 2`


### PR DESCRIPTION
fdisk lives in /usr/sbin/fdisk so it's not available to or in the $PATH of unprivileged users.

Without sudo, unless you build as root, you receive this error:
```
$ make embassyos-raspi.img ARCH=aarch64
...
make[1]: Leaving directory '/home/user/Dev/embassy-os/system-images/binfmt'
! test -f embassyos-raspi.img || rm embassyos-raspi.img
./build/raspberry-pi/make-image.sh
./build/raspberry-pi/make-image.sh: line 27: fdisk: command not found
make: *** [Makefile:67: embassyos-raspi.img] Error 127
make: *** Deleting file 'embassyos-raspi.img'
```
With the `sudo fidsk` in this fix, my make completed successfully as a regular user.