### PR TITLE
Better Updates Tab and updates count

### DIFF
--- a/frontend/projects/shared/src/util/misc.util.ts
+++ b/frontend/projects/shared/src/util/misc.util.ts
@@ -36,10 +36,6 @@ export function sameUrl(
   return toUrl(u1) === toUrl(u2)
 }
 
-export function getDomain(hostname: string) {
-  return hostname.split('.').slice(-2).join('.')
-}
-
 export function isValidHttpUrl(url: string): boolean {
   try {
     const _ = new URL(url)
@@ -47,10 +43,6 @@ export function isValidHttpUrl(url: string): boolean {
   } catch (_) {
     return false
   }
-}
-
-export function getUrlHostname(url: string): string {
-  return new URL(url).hostname
 }
 
 export function toUrl(text: string | null | undefined): string {

--- a/frontend/projects/shared/src/util/misc.util.ts
+++ b/frontend/projects/shared/src/util/misc.util.ts
@@ -36,19 +36,6 @@ export function sameUrl(
   return toUrl(u1) === toUrl(u2)
 }
 
-export function sameDomain(
-  u1: string | null | undefined,
-  u2: string | null | undefined,
-) {
-  const hostname1 = getUrlHostname(toUrl(u1))
-  const hostname2 = getUrlHostname(toUrl(u2))
-
-  const domain1 = getDomain(hostname1)
-  const domain2 = getDomain(hostname2)
-
-  return domain1 === domain2
-}
-
 export function getDomain(hostname: string) {
   return hostname.split('.').slice(-2).join('.')
 }

--- a/frontend/projects/shared/src/util/misc.util.ts
+++ b/frontend/projects/shared/src/util/misc.util.ts
@@ -36,6 +36,23 @@ export function sameUrl(
   return toUrl(u1) === toUrl(u2)
 }
 
+export function sameDomain(
+  u1: string | null | undefined,
+  u2: string | null | undefined,
+) {
+  const hostname1 = getUrlHostname(toUrl(u1))
+  const hostname2 = getUrlHostname(toUrl(u2))
+
+  const domain1 = getDomain(hostname1)
+  const domain2 = getDomain(hostname2)
+
+  return domain1 === domain2
+}
+
+export function getDomain(hostname: string) {
+  return hostname.split('.').slice(-2).join('.')
+}
+
 export function isValidHttpUrl(url: string): boolean {
   try {
     const _ = new URL(url)

--- a/frontend/projects/ui/src/app/app/menu/menu.component.ts
+++ b/frontend/projects/ui/src/app/app/menu/menu.component.ts
@@ -59,11 +59,10 @@ export class MenuComponent {
     map(([marketplace, local]) =>
       Object.entries(marketplace).reduce((list, [_, store]) => {
         store?.packages.forEach(({ manifest: { id, version } }) => {
-          if (!local[id]) return
           if (
             this.emver.compare(
               version,
-              local[id].installed?.manifest.version || '',
+              local[id]?.installed?.manifest.version || '',
             ) === 1
           )
             list.add(id)

--- a/frontend/projects/ui/src/app/pages/marketplace-routes/marketplace-list/marketplace-list.page.ts
+++ b/frontend/projects/ui/src/app/pages/marketplace-routes/marketplace-list/marketplace-list.page.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from '@angular/router'
 import { ModalController } from '@ionic/angular'
 import { AbstractMarketplaceService } from '@start9labs/marketplace'
 import { PatchDB } from 'patch-db-client'
-import { filter, map } from 'rxjs'
+import { map } from 'rxjs'
 import { MarketplaceSettingsPage } from 'src/app/modals/marketplace-settings/marketplace-settings.page'
 import { ConfigService } from 'src/app/services/config.service'
 import { MarketplaceService } from 'src/app/services/marketplace.service'
@@ -84,9 +84,6 @@ export class MarketplaceListPage {
   async presentModalMarketplaceSettings() {
     const modal = await this.modalCtrl.create({
       component: MarketplaceSettingsPage,
-    })
-    modal.onDidDismiss().then(res => {
-      console.log(res)
     })
     await modal.present()
   }

--- a/frontend/projects/ui/src/app/pages/updates/updates.page.html
+++ b/frontend/projects/ui/src/app/pages/updates/updates.page.html
@@ -26,7 +26,7 @@
           *ngIf="data.marketplace[host.url]?.packages as packages else loading"
         >
           <ng-container
-            *ngIf="packages | filterUpdates : data.localPkgs : host.url as updates"
+            *ngIf="packages | filterUpdates : data.localPkgs as updates"
           >
             <div *ngFor="let pkg of updates" class="item-container">
               <ion-item lines="none">

--- a/frontend/projects/ui/src/app/pages/updates/updates.page.ts
+++ b/frontend/projects/ui/src/app/pages/updates/updates.page.ts
@@ -175,19 +175,16 @@ export class FilterUpdatesPipe implements PipeTransform {
 
   transform(
     pkgs: MarketplacePkg[],
-    local: Record<string, PackageDataEntry>,
+    local: Record<string, PackageDataEntry | undefined>,
   ): MarketplacePkg[] {
     return pkgs.filter(({ manifest }) => {
-      const { id, version } = manifest
-      const localPkg = local[id]
-
-      if (!localPkg) return false
+      const localPkg = local[manifest.id]
 
       return (
-        local[id]?.state === PackageState.Updating ||
+        localPkg?.state === PackageState.Updating ||
         this.emver.compare(
-          version,
-          local[id].installed?.manifest.version || '',
+          manifest.version,
+          localPkg?.installed?.manifest.version || '',
         ) === 1
       )
     })

--- a/frontend/projects/ui/src/app/services/api/mock-patch.ts
+++ b/frontend/projects/ui/src/app/services/api/mock-patch.ts
@@ -20,7 +20,7 @@ export const mockPatchData: DataModel = {
           name: 'Start9 Registry',
         },
         'https://community-registry.start9.com/': {},
-        'https://dark9-marketplace.com/': {
+        'https://beta-registry.start9.com/': {
           name: 'Dark9',
         },
       },

--- a/frontend/projects/ui/src/app/services/marketplace.service.ts
+++ b/frontend/projects/ui/src/app/services/marketplace.service.ts
@@ -56,18 +56,18 @@ export class MarketplaceService implements AbstractMarketplaceService {
       }),
     )
 
-  private readonly filteredKnownHosts: Observable<StoreIdentity[]> =
+  private readonly filteredKnownHosts$: Observable<StoreIdentity[]> =
     combineLatest([
       this.clientStorageService.showDevTools$,
       this.knownHosts$,
     ]).pipe(
-      map(([devMode, knownHosts]) => {
-        if (devMode) return knownHosts
-
-        return knownHosts.filter(
-          ({ url }) => !url.includes('alpha') && !url.includes('beta'),
-        )
-      }),
+      map(([devMode, knownHosts]) =>
+        devMode
+          ? knownHosts
+          : knownHosts.filter(
+              ({ url }) => !url.includes('alpha') && !url.includes('beta'),
+            ),
+      ),
     )
 
   private readonly selectedHost$: Observable<StoreIdentity> = this.patch
@@ -113,15 +113,16 @@ export class MarketplaceService implements AbstractMarketplaceService {
     this.marketplace$,
   ]).pipe(
     map(([devMode, marketplace]) =>
-      Object.entries(marketplace).reduce((filtered, [url, store]) => {
-        if (!devMode && (url.includes('alpha') || url.includes('beta'))) {
-          return filtered
-        }
-        return {
-          [url]: store,
-          ...filtered,
-        }
-      }, {} as Marketplace),
+      Object.entries(marketplace).reduce(
+        (filtered, [url, store]) =>
+          !devMode && (url.includes('alpha') || url.includes('beta'))
+            ? filtered
+            : {
+                [url]: store,
+                ...filtered,
+              },
+        {} as Marketplace,
+      ),
     ),
   )
 
@@ -146,7 +147,8 @@ export class MarketplaceService implements AbstractMarketplaceService {
   ) {}
 
   getKnownHosts$(filtered = false): Observable<StoreIdentity[]> {
-    return filtered ? this.filteredKnownHosts : this.knownHosts$
+    // option to filter out hosts containing 'alpha' or 'beta' substrings in registryURL
+    return filtered ? this.filteredKnownHosts$ : this.knownHosts$
   }
 
   getSelectedHost$(): Observable<StoreIdentity> {
@@ -154,6 +156,7 @@ export class MarketplaceService implements AbstractMarketplaceService {
   }
 
   getMarketplace$(filtered = false): Observable<Marketplace> {
+    // option to filter out hosts containing 'alpha' or 'beta' substrings in registryURL
     return filtered ? this.filteredMarketplace$ : this.marketplace$
   }
 


### PR DESCRIPTION
**Goals**
1. Registries containing the string 'alpha' or 'beta' should only show in the Updates Tab and count towards updates badge count if dev tools enabled.
2. In the Updates Tab, service updates should show in _every_ registry where there is an update available (not just the registry from which it was originally installed)
3. Updates badge count should be de-duplicated. For example, if there is an update available for Bitcoin in 3 different registries, the badge should only count that as 1.