### PR TITLE
sdk: don't allow mounts in inject actions

### DIFF
--- a/backend/src/procedure/docker.rs
+++ b/backend/src/procedure/docker.rs
@@ -209,6 +209,9 @@ impl DockerProcedure {
         if expected_io && self.io_format.is_none() {
             color_eyre::eyre::bail!("expected io-format");
         }
+        if self.inject && !self.mounts.is_empty() {
+            color_eyre::eyre::bail!("mounts not allowed in inject actions");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This check has disappeared somehow. Adding it back.