### PR TITLE
fix: Add type of archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ frontend/config.json: $(GIT_HASH_FILE) frontend/config-sample.json
 	npm --prefix frontend run-script build-config
 
 frontend/patchdb-ui-seed.json: frontend/package.json
-	jq '."ack-welcome" = "$(shell yq '.version' frontend/package.json)"' frontend/patchdb-ui-seed.json > ui-seed.tmp
+	jq '."ack-welcome" = $(shell yq '.version' frontend/package.json)' frontend/patchdb-ui-seed.json > ui-seed.tmp
 	mv ui-seed.tmp frontend/patchdb-ui-seed.json
 
 patch-db/client/node_modules: patch-db/client/package.json

--- a/backend/src/setup.rs
+++ b/backend/src/setup.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use color_eyre::eyre::eyre;
 use futures::StreamExt;
-use helpers::{Rsync, RsyncOptions};
+use helpers::{Rsync, RsyncOptions, RsyncOptionsArchive};
 use josekit::jwk::Jwk;
 use openssl::x509::X509;
 use patch_db::DbHandle;
@@ -430,6 +430,7 @@ async fn migrate(
             exclude: Vec::new(),
             no_permissions: false,
             no_owner: false,
+            archive: RsyncOptionsArchive::default(),
         },
     )
     .await?;
@@ -443,6 +444,7 @@ async fn migrate(
             exclude: vec!["tmp".to_owned()],
             no_permissions: false,
             no_owner: false,
+            archive: RsyncOptionsArchive::default(),
         },
     )
     .await?;

--- a/backend/src/update/mod.rs
+++ b/backend/src/update/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use clap::ArgMatches;
 use color_eyre::eyre::{eyre, Result};
 use emver::Version;
-use helpers::{Rsync, RsyncOptions};
+use helpers::{Rsync, RsyncOptions, RsyncOptionsArchive};
 use lazy_static::lazy_static;
 use patch_db::{DbHandle, LockType, Revision};
 use reqwest::Url;
@@ -307,6 +307,7 @@ async fn sync_boot() -> Result<(), Error> {
             exclude: Vec::new(),
             no_permissions: false,
             no_owner: false,
+            archive: RsyncOptionsArchive::default(),
         },
     )
     .await?

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -3312,7 +3312,7 @@ checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.0",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",


### PR DESCRIPTION
### About 

So, we have noticed the following error. 
We back up a service that uses rsync, like nostr.
We backup to exfat, fat32, and (probably ntfs)
Then the backup fails.

### Research

There are so many options that are part of the archive, and windows won't support almost most of them.
This still doesn't solve the length and name too long. But if we do just a simple recursive it will work on the exfat drives.

### Downsides

Now the default is not going to preserve dates, user information, permissions, or links (soft/hard)

### Proof of working 

https://user-images.githubusercontent.com/2364004/227014330-0f55c09e-a85d-4a0c-b6f4-fa94191dfad2.mp4


