### PR TITLE
Add sans-serif font fallback

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -52,8 +52,8 @@ Valid values for "maskAs" are `tor` and `lan`.
 ```sh
 npm run start:ui
 npm run start:install-wiz
-npm run start:setup-wizard
-npm run start:diagnostic-ui
+npm run start:setup
+npm run start:dui
 ```
 
 ## Running locally with proxied backend

--- a/frontend/projects/diagnostic-ui/src/styles.scss
+++ b/frontend/projects/diagnostic-ui/src/styles.scss
@@ -7,7 +7,7 @@
 
 /** Ionic CSS Variables overrides **/
 :root {
-  --ion-font-family: 'Montserrat';
+  --ion-font-family: 'Montserrat', sans-serif;
 
   --ion-color-primary: #0075e1;
 

--- a/frontend/projects/install-wizard/src/app/pages/home/home.page.scss
+++ b/frontend/projects/install-wizard/src/app/pages/home/home.page.scss
@@ -1,6 +1,6 @@
 /** Ionic CSS Variables overrides **/
 :root {
-  --ion-font-family: 'Benton Sans';
+  --ion-font-family: 'Benton Sans', sans-serif;
 }
 
 ion-content {

--- a/frontend/projects/install-wizard/src/styles.scss
+++ b/frontend/projects/install-wizard/src/styles.scss
@@ -7,7 +7,7 @@
 
 /** Ionic CSS Variables overrides **/
 :root {
-  --ion-font-family: 'Montserrat';
+  --ion-font-family: 'Montserrat', sans-serif;
 
   --ion-color-primary: #0075e1;
 

--- a/frontend/projects/setup-wizard/src/app/pages/success/download-doc/download-doc.component.html
+++ b/frontend/projects/setup-wizard/src/app/pages/success/download-doc/download-doc.component.html
@@ -6,7 +6,7 @@
   <body>
     <div
       style="
-        font-family: Montserrat;
+        font-family: Montserrat, sans-serif;
         color: #333333;
         display: flex;
         flex-direction: column;

--- a/frontend/projects/setup-wizard/src/styles.scss
+++ b/frontend/projects/setup-wizard/src/styles.scss
@@ -84,7 +84,7 @@
 
 /** Ionic CSS Variables overrides **/
 :root {
-  --ion-font-family: 'Montserrat';
+  --ion-font-family: 'Montserrat', sans-serif;
 
   --ion-background-color: #333333;
   --ion-background-color-rgb: 51, 51, 51;
@@ -114,7 +114,7 @@
 
 
   --ion-color-dark: var(--ion-color-step-50) !important;
-  // --ion-color-base-rgb: 
+  // --ion-color-base-rgb:
   --ion-color-dark-contrast: var(--ion-color-step-950) !important;
   // --ion-color-dark-contrast-rgb:
   --ion-color-dark-shade: var(--ion-color-step-100) !important;
@@ -144,7 +144,7 @@ h1 {
 
 ion-card-title {
   margin: 16px 0;
-  font-family: 'Montserrat';
+  font-family: 'Montserrat', sans-serif;
   font-size: x-large;
   --color: var(--ion-color-light);
 }
@@ -165,7 +165,7 @@ ion-label ion-text {
 p {
   color: var(--ion-color-dark-contrast) !important;
   font-size: 1.12rem !important;
-  font-family: 'Open Sans';
+  font-family: 'Open Sans', sans-serif;
   font-weight: normal;
 }
 
@@ -313,7 +313,7 @@ ion-header {
   ion-toolbar {
     --border-color: var(--ion-color-step-950);
     --border-width: 0 0 1px 0;
-  
+
     --min-height: 80px;
     --padding-top: 20px;
     --padding-bottom: 20px;

--- a/frontend/projects/ui/src/app/components/widget-card/widget-card.component.scss
+++ b/frontend/projects/ui/src/app/components/widget-card/widget-card.component.scss
@@ -14,9 +14,9 @@ ion-card {
     transform: scale(1.05);
     transition-delay: 40ms;
   }
-  
+
   ion-card-title {
-    font-family: 'Open Sans';
+    font-family: 'Open Sans', sans-serif;
     padding: 0.6rem;
     font-weight: 600;
     font-size: calc(12px + 0.5vw);
@@ -29,16 +29,16 @@ ion-card {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    
+
     ion-icon {
       font-size: calc(90px + 0.5vw);
       --ionicon-stroke-width: 1rem;
     }
   }
-  
+
   ion-footer {
     padding: 1rem;
-    font-family: 'Open Sans';
+    font-family: 'Open Sans', sans-serif;
     font-size: clamp(1rem, calc(12px + 0.5vw), 1.3rem);
     height: 9rem;
     width: clamp(13rem, 80%, 18rem);

--- a/frontend/projects/ui/src/styles.scss
+++ b/frontend/projects/ui/src/styles.scss
@@ -70,7 +70,7 @@
 
 /** Ionic CSS Variables overrides **/
 :root {
-  --ion-font-family: 'Open Sans';
+  --ion-font-family: 'Open Sans', sans-serif;
   --ion-background-color: var(--ion-color-medium);
   --ion-background-color-rgb: var(--ion-color-medium-rgb);
   --ion-text-color: var(--ion-color-dark);
@@ -186,11 +186,11 @@ ion-back-button {
 }
 
 ion-card-title {
-  font-family: 'Montserrat';
+  font-family: 'Montserrat', sans-serif;
 }
 
 ion-title {
-  font-family: 'Montserrat';
+  font-family: 'Montserrat', sans-serif;
 }
 
 ion-badge {


### PR DESCRIPTION
While the fonts are loading, headings default to a serif font, so it looks a bit funny and it's more jarring when the sans-serif fonts load.

Some places already had a fallback (e.g. the [side navigation](https://github.com/Start9Labs/embassy-os/blob/master/frontend/projects/shared/styles/shared.scss#L114)), this PR just adds it everywhere else.

## Screenshots

### Before

![Screenshot from 2023-05-05 13-45-24](https://user-images.githubusercontent.com/7598058/236377805-ac964c70-bda6-4744-b7c6-7955dfbddff5.png)

### After

![Screenshot from 2023-05-05 13-45-47](https://user-images.githubusercontent.com/7598058/236377800-27db8aed-48da-4a00-aa50-630751633c1a.png)


## Resources

- https://css-tricks.com/css-basics-fallback-font-stacks-robust-web-typography/